### PR TITLE
Silence console messages

### DIFF
--- a/components/teaching/TeachingListItem.tsx
+++ b/components/teaching/TeachingListItem.tsx
@@ -81,7 +81,7 @@ export default function TeachingListItem({ teaching, handlePress }: Params): JSX
                 if (json.data?.getCommentsByOwner?.items && json.data?.getCommentsByOwner?.items?.length > 0)
                     setHasComments(true)
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         }
         getComments();

--- a/screens/Auth/ForgotPassword.tsx
+++ b/screens/Auth/ForgotPassword.tsx
@@ -118,7 +118,7 @@ export default function Login({ navigation }: Params): JSX.Element {
         try {
             await Auth.forgotPassword(user).then(() => updateCodeState(true))
         } catch (e) {
-            console.error(e)
+            console.debug(e)
             if (e.code === "UserNotFoundException")
                 setError('Username not found.')
             else if (e.code === 'InvalidPasswordException')
@@ -136,7 +136,7 @@ export default function Login({ navigation }: Params): JSX.Element {
             updateCodeState(true);
             toLogin();
         } catch (e) {
-            console.error(e)
+            console.debug(e)
             setError(e.message)
         }
     }

--- a/screens/Auth/Login.tsx
+++ b/screens/Auth/Login.tsx
@@ -134,7 +134,7 @@ export default function Login({ navigation }: Params): JSX.Element {
             });
             navigateHome();
         } catch (e) {
-            console.error(e)
+            console.debug(e)
             setError(e.message)
         }
     }

--- a/screens/CommentScreen.tsx
+++ b/screens/CommentScreen.tsx
@@ -247,7 +247,7 @@ export default function CommentScreen({ navigation, route }: Params): JSX.Elemen
                     })
                 }
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         }
 
@@ -284,7 +284,7 @@ export default function CommentScreen({ navigation, route }: Params): JSX.Elemen
 
             navigation.goBack();
         } catch (e) {
-            console.error(e)
+            console.debug(e)
         }
     }
 
@@ -312,7 +312,7 @@ export default function CommentScreen({ navigation, route }: Params): JSX.Elemen
                 navigation.goBack();
 
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         } else if ('key' in routeParams && comment) {
             try {
@@ -347,7 +347,7 @@ export default function CommentScreen({ navigation, route }: Params): JSX.Elemen
                 navigation.goBack();
 
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         }
     }

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -80,11 +80,11 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
           </View>
         </View>
 
-        <View style={style.categoryContainer}>
+        {images && images.length > 1 ? <View style={style.categoryContainer}>
           <Text style={style.categoryTitle}>@{instaUsername}</Text>
           <InstagramFeed images={images} />
           <AllButton handlePress={() => Linking.openURL(`https://instagram.com/${instaUsername}`)} icon={Theme.icons.white.instagram}>Follow us on Instagram</AllButton>
-        </View>
+        </View> : null}
 
 
         {/*<View style={style.categoryContainer}>

--- a/screens/LocationSelectionScreen.tsx
+++ b/screens/LocationSelectionScreen.tsx
@@ -108,14 +108,14 @@ export default function LocationSelectionScreen({ navigation, route }: LocationS
                 const update = await Auth.updateUserAttributes(user, { ...user.attributes, 'custom:home_location': locationId });
                 console.log(update);
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         } else if (locationId) {
             try {
                 const updateLocalStore = await SecureStore.setItemAsync('location', locationId);
                 console.log(updateLocalStore)
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         } else {
             console.debug('locationId is undefined');

--- a/screens/NotesScreen.tsx
+++ b/screens/NotesScreen.tsx
@@ -270,7 +270,7 @@ export default function NotesScreen({ route, navigation }: Params): JSX.Element 
                     if (json.data?.getCommentsByOwner?.items)
                         commentContext.setComments(json.data?.getCommentsByOwner?.items)
                 } catch (e) {
-                    console.error(e)
+                    console.debug(e)
                 }
         }
         getComments();
@@ -300,7 +300,7 @@ export default function NotesScreen({ route, navigation }: Params): JSX.Element 
                 const update = await Auth.updateUserAttributes(user, { ...user.attributes, 'custom:preference_openBible': openIn });
                 console.log(update);
             } catch (e) {
-                console.error(e)
+                console.debug(e)
             }
         }
 

--- a/services/Instagram.ts
+++ b/services/Instagram.ts
@@ -64,7 +64,7 @@ export default class InstagramService {
       }
 
     } catch (e) {
-      console.error(e)
+      console.debug(e)
     }
     return { images: [], username: '' }
   }


### PR DESCRIPTION
Uses `console.debug` instead of `console.error` so the Expo client doesn't throw an error screen.