### PR TITLE
Patch external links on iOS 14

### DIFF
--- a/components/teaching/notes/TextComponents.tsx
+++ b/components/teaching/notes/TextComponents.tsx
@@ -299,13 +299,11 @@ export function HyperLink({ block, links, styles, openVerseCallback, verses, typ
             setPassage(link);
             setShow(link.offset === passage.offset ? !show : true);
         } else {
-            const canOpen = await Linking.canOpenURL(link.uri);
-            if (canOpen)
-                try {
-                    await Linking.openURL(link.uri)
-                } catch (e) {
-                    console.debug(e)
-                }
+            try {
+                await Linking.openURL(link.uri)
+            } catch (e) {
+                console.debug(e)
+            }
         }
     }
 


### PR DESCRIPTION
Removes the `Linking.canOpenURL()` call, which resolves the issue. Reading the Expo docs a little more carefully, this function is only required to "non-standard" links e.g. for Lyft. 