### PR TITLE
Home screen fixes

### DIFF
--- a/components/home/RecentTeaching/RecentTeaching.tsx
+++ b/components/home/RecentTeaching/RecentTeaching.tsx
@@ -4,22 +4,19 @@ import { Image, StyleSheet, Dimensions, TouchableWithoutFeedback } from 'react-n
 import { Theme, Style } from '../../../Theme.style';
 import IconButton from '../../buttons/IconButton';
 import moment from 'moment';
-import { useNavigation, CompositeNavigationProp } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import { GetVideoByVideoTypeQuery, GetVideoByVideoTypeQueryVariables, ModelSortDirection, GetNotesQuery } from '../../../services/API';
 import { MainStackParamList } from '../../../navigation/AppNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
 import ActivityIndicator from '../../../components/ActivityIndicator';
 import { API, GraphQLResult, graphqlOperation } from '@aws-amplify/api';
 import NotesService from '../../../services/NotesService';
-import { TeachingStackParamList } from '../../../navigation/MainTabNavigator';
 
 const screenWidth = Dimensions.get('window').width;
 
 const style = StyleSheet.create({
     container: {
         alignItems: "center",
-        marginLeft: 16,
-        marginRight: 16,
         backgroundColor: Theme.colors.black,
     },
     teachingImage: {
@@ -69,7 +66,7 @@ type VideoData = NonNullable<NonNullable<GetVideoByVideoTypeQuery['getVideoByVid
 
 export default function RecentTeaching(): JSX.Element {
 
-    const navigation = useNavigation<CompositeNavigationProp<StackNavigationProp<MainStackParamList>, StackNavigationProp<TeachingStackParamList>>>();
+    const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
     const [teaching, setTeaching] = useState<VideoData>(null);
     const [note, setNote] = useState<GetNotesQuery['getNotes']>();
     const [fullDescription, setFullDescription] = useState(false);
@@ -134,15 +131,15 @@ export default function RecentTeaching(): JSX.Element {
                         <TouchableWithoutFeedback onPress={() => navigation.navigate('SermonLandingScreen', { item: teaching })} >
                             <Image style={style.teachingImage} source={{ uri: teachingImage.url }} />
                         </TouchableWithoutFeedback>
-                        <TouchableWithoutFeedback onPress={() => navigation.navigate('SeriesLandingScreen', { seriesId: teaching.series?.id })}>
-                            <Image style={[style.seriesImage, style.seriesImageWithTeachingImage]} source={{ uri: seriesImageUri }} />
-                        </TouchableWithoutFeedback>
+                        <Image style={[style.seriesImage, style.seriesImageWithTeachingImage]} source={{ uri: seriesImageUri }} />
                     </View>
                     : <Image style={style.seriesImage} source={{ uri: seriesImageUri }}></Image>
                 }
-                <Text style={style.title}>{teaching.episodeTitle}</Text>
-                <Text style={style.subtitle}>{moment(teaching.publishedDate as string).format("MMMM D, YYYY")}</Text>
-                <Text style={style.description} numberOfLines={fullDescription ? undefined : 2} ellipsizeMode='tail' onPress={() => setFullDescription(!fullDescription)}>{teaching.description}</Text>
+                <View style={{ marginHorizontal: 16, alignItems: 'center' }} >
+                    <Text style={style.title}>{teaching.episodeTitle}</Text>
+                    <Text style={style.subtitle}>{moment(teaching.publishedDate as string).format("MMMM D, YYYY")}</Text>
+                    <Text style={style.description} numberOfLines={fullDescription ? undefined : 2} ellipsizeMode='tail' onPress={() => setFullDescription(!fullDescription)}>{teaching.description}</Text>
+                </View>
                 <View>
                     <IconButton icon={Theme.icons.white.notes} label="Notes" onPress={openNotes}></IconButton>
                 </View>

--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import MainTabNavigator from './MainTabNavigator';
+import MainTabNavigator, {
+  TabNavigatorParamList,
+  HomeStackParamList,
+  TeachingStackParamList,
+  MoreStackParamList
+} from './MainTabNavigator';
 import AuthNavigator from './AuthNavigator';
 import { createStackNavigator } from '@react-navigation/stack';
-import { TabNavigatorParamList, HomeStackParamList } from './MainTabNavigator';
 import { AuthStackParamList } from './AuthNavigator';
 import NotesScreen from '../screens/NotesScreen';
 import CommentScreen from '../screens/CommentScreen';
@@ -16,7 +20,15 @@ import SermonLandingScreen from '../screens/SermonLandingScreen';
 import { CommentDataType } from '../services/API';
 
 export type MainStackParamList = {
-  Main: undefined | { screen: keyof TabNavigatorParamList, params: { screen: keyof HomeStackParamList } };
+  Main: undefined | {
+    screen: keyof TabNavigatorParamList, params: {
+      screen:
+      keyof HomeStackParamList |
+      keyof TeachingStackParamList |
+      keyof MoreStackParamList,
+      params: any
+    }
+  };
   Auth: undefined | { screen: keyof AuthStackParamList };
   NotesScreen: { date: string };
   ProfileScreen: undefined;
@@ -26,7 +38,22 @@ export type MainStackParamList = {
   HighlightScreen: { highlights: any[], nextToken: string | undefined };
   DateRangeSelectScreen: undefined;
   SermonLandingScreen: { item: any };
-  CommentScreen: { key: string, noteId: string, commentType: CommentDataType, noteType: 'notes' | 'questions', textSnippet?: string, imageUri?: string } | { commentId: string, comment: string, tags: Array<string | null>, textSnippet?: string, imageUri?: string, commentType: CommentDataType, noteId: string };
+  CommentScreen: {
+    key: string,
+    noteId: string,
+    commentType: CommentDataType,
+    noteType: 'notes' | 'questions', t
+    extSnippet?: string,
+    imageUri?: string
+  } | {
+    commentId: string,
+    comment: string,
+    tags: Array<string | null>,
+    textSnippet?: string,
+    imageUri?: string,
+    commentType: CommentDataType,
+    noteId: string
+  };
 }
 
 const Main = createStackNavigator<MainStackParamList>();


### PR DESCRIPTION
Caught some minor bugs in the latest release.

Fixes a styling issue with the video thumbnail on the home screen.

The series image on the home screen is no longer pressable. This is because of the home stack and teaching stacks are parallel in the navigation tree, so jumping from the home screen to the series landing screen is inconsistent. I think removing the feature is better than keeping the bugs. 