### PR TITLE
Regex fix

### DIFF
--- a/screens/Auth/SignUp.tsx
+++ b/screens/Auth/SignUp.tsx
@@ -209,7 +209,7 @@ export default function SignUp({ navigation }: Params): JSX.Element {
                 <PasswordRequirement meetsRequirement={pass.length >= 8} requirement='8 characters' />
                 <PasswordRequirement meetsRequirement={/(?=.*[A-Z])/.test(pass)} requirement='upper &amp; lowercase letters' />
                 <PasswordRequirement meetsRequirement={/(?=.*[0-9])/.test(pass)} requirement='1 number' />
-                <PasswordRequirement meetsRequirement={/(?=.*[\^$*.\[\]{}\(\)?\-“!@#%&/,><\’:;|_~`])/.test(pass)} requirement='1 special character (e.g. @ ! $ ^ ?)' />
+                <PasswordRequirement meetsRequirement={/(?=.*[\=\+\$\*\.\,\?\"\!\@\#\%\&\'\:\;\[\]\{\}\(\)\/\\\>\<\|\_\~\`\^\-])/.test(pass)} requirement='1 special character (e.g. @ ! $ ^ ?)' />
             </View>
             <Text style={style.title}>Choose Your Location</Text>
             <TouchableOpacity style={style.locationSelector} onPress={() => navigation.push('LocationSelectionScreen')} >


### PR DESCRIPTION
Closes #87 (again). The issue did not persist on the Expo client (the issue seems to be post-build only). Nevertheless, this should solve the issue. All special characters are escaped, so they will be interpreted as literals.