### PR TITLE
Remove excess padding from share modal on event screen

### DIFF
--- a/screens/EventDetailsScreen.tsx
+++ b/screens/EventDetailsScreen.tsx
@@ -270,7 +270,7 @@ export default function EventDetailsScreen(props: Props): JSX.Element {
 
             </Content>
             {
-                share ? <ShareModal closeCallback={() => setShare(false)}
+                share ? <ShareModal noBottomPadding closeCallback={() => setShare(false)}
                     link={`https://www.facebook.com/events/${eventItem.id}`}
                     message={eventItem !== null ? `Check out this event: \n${eventItem?.name}\n${eventItem?.place?.name}` : ``} /> : null
             }


### PR DESCRIPTION
Quick fix (just adding the prop). 

The share modal should have the `noBottomPadding` prop if the screen has the bottom tab.