### PR TITLE
All series and All teaching performance improvements

### DIFF
--- a/screens/AllSeriesScreen.tsx
+++ b/screens/AllSeriesScreen.tsx
@@ -11,6 +11,7 @@ import { TeachingStackParamList } from '../navigation/MainTabNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { TouchableHighlight } from 'react-native-gesture-handler';
 import FallbackImage from '../components/FallbackImage';
+import AllButton from '../components//buttons/AllButton';
 
 const width = Dimensions.get('screen').width;
 
@@ -97,7 +98,7 @@ export default function AllSeriesScreen({ navigation }: Params): JSX.Element {
     const [searchText, setSearchText] = useState("");
     const [selectedYear, setSelectedYear] = useState("All");
     const [seriesYears, setSeriesYears] = useState(["All"])
-
+    const [showCount, setShowCount] = useState(20);
     const [allSeries, setAllSeries] = useState({ loading: true, items: [], nextToken: null });
 
     const loadAllSeriesAsync = async () => {
@@ -119,12 +120,11 @@ export default function AllSeriesScreen({ navigation }: Params): JSX.Element {
         generateYears();
         loadAllSeriesAsync();
     }, [])
-
-    const series = allSeries.items.filter((s: any) => searchText ? s.title.toLowerCase().includes(searchText.toLowerCase()) : true);
-
     const getSeriesDate = (series: any) => {
         return moment(series.startDate || moment()).format("YYYY");
     }
+    const series = allSeries.items.filter((s: any) => searchText ? s.title.toLowerCase().includes(searchText.toLowerCase()) : true).filter((a) => { return selectedYear === "All" || getSeriesDate(a) === selectedYear }).filter((a) => { return selectedYear === "All" || getSeriesDate(a) === selectedYear });;
+
 
     navigation.setOptions({
         headerShown: true,
@@ -169,14 +169,24 @@ export default function AllSeriesScreen({ navigation }: Params): JSX.Element {
                             <ActivityIndicator />
                         </View>
                     }
-                    {series.map((s: any) => (
-                        (selectedYear === "All" || getSeriesDate(s) === selectedYear) &&
-                        <TouchableOpacity onPress={() => navigation.push('SeriesLandingScreen', { seriesId: s.id })} style={style.seriesItem} key={s.id}>
-                            <FallbackImage style={style.seriesThumbnail} uri={s.image} catchUri='https://www.themeetinghouse.com/static/photos/series/series-fallback-app.jpg' />
-                            <Text style={style.seriesDetail}>{getSeriesDate(s)} &bull; {s.videos.items.length} episodes</Text>
-                        </TouchableOpacity>
-                    ))}
+                    {series.map((s: any, key: any) => {
+                        if (key < showCount) {
+                            return (
+                                <TouchableOpacity onPress={() => navigation.push('SeriesLandingScreen', { seriesId: s.id })} style={style.seriesItem} key={s.id}>
+                                    <FallbackImage style={style.seriesThumbnail} uri={s.image} catchUri='https://www.themeetinghouse.com/static/photos/series/series-fallback-app.jpg' />
+                                    <Text style={style.seriesDetail}>{getSeriesDate(s)} &bull; {s.videos.items.length} episodes</Text>
+                                </TouchableOpacity>)
+                        } else {
+                            return null
+                        }
+                    })}
+
                 </View>
+                {series?.length > 20 && showCount < series.length ?
+                    <View style={{ marginBottom: 20 }}>
+                        <AllButton handlePress={() => setShowCount(showCount + 20)}>Load More</AllButton>
+                    </View>
+                    : null}
             </Content>
         </Container>
     )

--- a/screens/AllSermonsScreen.tsx
+++ b/screens/AllSermonsScreen.tsx
@@ -140,7 +140,10 @@ export default function AllSermonsScreen({ navigation, route }: Params): JSX.Ele
                     placeholderLabel="Search by name..."></SearchBar>
                 <View style={style.dateSelectBar}>
 
-                    <TouchableHighlight style={{ borderRadius: 50, overflow: 'hidden', marginRight: 8 }} onPress={() => { navigation.push('DateRangeSelectScreen') }} underlayColor={Theme.colors.grey3}  >
+                    <TouchableHighlight style={{ borderRadius: 50, overflow: 'hidden', marginRight: 8 }} onPress={() => {
+                        setShowCount(20);
+                        navigation.push('DateRangeSelectScreen')
+                    }} underlayColor={Theme.colors.grey3}  >
                         {(dateStart && dateEnd)
                             ? isSame
                                 ? <Text style={style.dateRangeItemText}>{dateEndStr}</Text>

--- a/screens/AllSermonsScreen.tsx
+++ b/screens/AllSermonsScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Theme, Style, HeaderStyle } from '../Theme.style';
 import { Container, Text, Content, View, Thumbnail } from 'native-base';
 import moment from 'moment';
-import { TouchableOpacity, StyleSheet, TouchableHighlight, Platform } from 'react-native';
+import { TouchableOpacity, StyleSheet, TouchableHighlight, Platform, Button } from 'react-native';
 import SearchBar from '../components/SearchBar';
 import TeachingListItem from '../components/teaching/TeachingListItem';
 import ActivityIndicator from '../components/ActivityIndicator';
@@ -12,6 +12,7 @@ import { RouteProp } from '@react-navigation/native';
 import { MainStackParamList } from 'navigation/AppNavigator';
 import API, { graphqlOperation, GraphQLResult } from '@aws-amplify/api';
 import { GetVideoByVideoTypeQuery, GetVideoByVideoTypeQueryVariables, ModelSortDirection } from '../services/API';
+import AllButton from '../components/buttons/AllButton'
 
 const style = StyleSheet.create({
     content: {
@@ -76,6 +77,7 @@ export default function AllSermonsScreen({ navigation, route }: Params): JSX.Ele
     const dateEnd = route.params?.endDate ? moment(route.params?.endDate)?.endOf('month') : null;
     const [searchText, setSearchText] = useState("");
     const [sermons, setSermons] = useState<VideoData>([]);
+    const [showCount, setShowCount] = useState(20);
     const [blurred, setBlurred] = useState(false);
 
     useEffect(() => {
@@ -148,15 +150,29 @@ export default function AllSermonsScreen({ navigation, route }: Params): JSX.Ele
                 </View>
                 <View>
                     {sermons && sermons.length > 0 ?
-                        filteredSermons.map((sermon: any) => (
-                            <TeachingListItem
-                                key={sermon.id}
-                                teaching={sermon}
-                                handlePress={() =>
-                                    navigation.push('SermonLandingScreen', { item: sermon })
-                                } />))
+                        filteredSermons.map((sermon: any, key: any) => {
+                            if (key < showCount)
+                                return (<TeachingListItem
+                                    key={sermon.id}
+                                    teaching={sermon}
+                                    handlePress={() =>
+                                        navigation.push('SermonLandingScreen', { item: sermon })
+                                    } />)
+                            else {
+                                return null
+                            }
+                        }
+                        )
                         : <ActivityIndicator />}
+                    {filteredSermons?.length > 20 && showCount < filteredSermons.length ?
+
+                        <View style={{ marginBottom: 20 }}>
+                            <AllButton handlePress={() => setShowCount(showCount + 20)}>Load More</AllButton>
+                        </View>
+                        : null}
+
                 </View>
+
             </Content>
         </Container>
     )


### PR DESCRIPTION
App breaking performance issues on All Series and All Sermons/Teaching screens.

- Added simple client-side pagination to improve performance
- All items are still fetched and stored in state but render incremental +20
- Load more button at the bottom of the page loads 20 more items.
- Performance issue still occurs after several clicks on "load more". It is assumed users would just want to use the date filter at that point but more work is definitely needed on this.

Stop gap measures for Issue #64 