### PR TITLE
Live Events Feature

### DIFF
--- a/components/teaching/notes/NoteReader.tsx
+++ b/components/teaching/notes/NoteReader.tsx
@@ -142,14 +142,12 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
                 const data = entityMap[entity.key];
                 switch (data.type) {
                     case "IMAGE":
-                        if (route.name !== "LiveStreamScreen") {
-                            if (numberOfImages === 0)
-                                markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
-                            else
-                                markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)
+                        if (numberOfImages === 0)
+                            markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
+                        else
+                            markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)
+                        numberOfImages++
 
-                            numberOfImages++
-                        }
                         break;
                     case "LINK":
                         links.push({ text: block.text.slice(entity.offset, entity.offset + entity.length), offset: entity.offset, length: entity.length, uri: data.data.url });

--- a/components/teaching/notes/NoteReader.tsx
+++ b/components/teaching/notes/NoteReader.tsx
@@ -3,9 +3,6 @@ import { View, StyleSheet, TextStyle } from 'react-native';
 import { Theme } from '../../../Theme.style';
 import { HyperLink, CustomHeading, CustomImage, CustomListItem, CustomText, HeaderImage } from './TextComponents';
 import { GetNotesQuery } from '../../../services/API';
-import { MainStackParamList } from 'navigation/AppNavigator';
-import { HomeStackParamList } from 'navigation/MainTabNavigator';
-import { RouteProp } from '@react-navigation/native';
 
 type ContentType =
     "unstyled" |
@@ -56,10 +53,10 @@ interface NoteReaderParams {
     verses: VerseType;
     date: string;
     noteId: string;
-    route: RouteProp<MainStackParamList | HomeStackParamList, 'NotesScreen' | 'LiveStreamScreen'>
+    fromLiveStream: boolean | undefined;
 }
 
-export default function NoteReader({ blocks, entityMap, mode, fontScale, type, openVerseCallback, verses, date, noteId, route }: NoteReaderParams): JSX.Element {
+export default function NoteReader({ blocks, entityMap, mode, fontScale, type, openVerseCallback, verses, date, noteId, fromLiveStream }: NoteReaderParams): JSX.Element {
 
     const color = mode === 'dark' ? 'white' : 'black'
     const styles = StyleSheet.create({
@@ -143,14 +140,13 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
                 switch (data.type) {
                     case "IMAGE":
                         if (numberOfImages === 0){
-                            if(route.name!=="LiveStreamScreen") {//this removes the first header image when coming from livestreamscreen. 
+                            if(!fromLiveStream) { //this removes the first header image when coming from livestreamscreen. 
                                 markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
                             }
                         }
                         else
                             markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)                       
                         numberOfImages++
-
                         break;
                     case "LINK":
                         links.push({ text: block.text.slice(entity.offset, entity.offset + entity.length), offset: entity.offset, length: entity.length, uri: data.data.url });
@@ -206,7 +202,7 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
         }
     }
 
-    return <View style={route.name === "LiveStreamScreen" &&  type === "notes" ? { width: '100%', marginBottom: 48, marginTop: -18 } : { width: '100%', marginBottom: 48, marginTop: 12 }} >
+    return <View style={fromLiveStream && type === "notes" ? { width: '100%', marginBottom: 48, marginTop: -18 } : { width: '100%', marginBottom: 48, marginTop: 12 }} >
         {markupArray.map(item => { return item })}
     </View>
 

--- a/components/teaching/notes/NoteReader.tsx
+++ b/components/teaching/notes/NoteReader.tsx
@@ -3,6 +3,9 @@ import { View, StyleSheet, TextStyle } from 'react-native';
 import { Theme } from '../../../Theme.style';
 import { HyperLink, CustomHeading, CustomImage, CustomListItem, CustomText, HeaderImage } from './TextComponents';
 import { GetNotesQuery } from '../../../services/API';
+import { MainStackParamList } from 'navigation/AppNavigator';
+import { HomeStackParamList } from 'navigation/MainTabNavigator';
+import { RouteProp } from '@react-navigation/native';
 
 type ContentType =
     "unstyled" |
@@ -53,9 +56,10 @@ interface NoteReaderParams {
     verses: VerseType;
     date: string;
     noteId: string;
+    route: RouteProp<MainStackParamList | HomeStackParamList, 'NotesScreen' | 'LiveStreamScreen'>
 }
 
-export default function NoteReader({ blocks, entityMap, mode, fontScale, type, openVerseCallback, verses, date, noteId }: NoteReaderParams): JSX.Element {
+export default function NoteReader({ blocks, entityMap, mode, fontScale, type, openVerseCallback, verses, date, noteId, route }: NoteReaderParams): JSX.Element {
 
     const color = mode === 'dark' ? 'white' : 'black'
     const styles = StyleSheet.create({
@@ -138,11 +142,14 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
                 const data = entityMap[entity.key];
                 switch (data.type) {
                     case "IMAGE":
-                        if (numberOfImages === 0)
-                            markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
-                        else
-                            markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)
-                        numberOfImages++
+                        if (route.name !== "LiveStreamScreen") {
+                            if (numberOfImages === 0)
+                                markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
+                            else
+                                markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)
+
+                            numberOfImages++
+                        }
                         break;
                     case "LINK":
                         links.push({ text: block.text.slice(entity.offset, entity.offset + entity.length), offset: entity.offset, length: entity.length, uri: data.data.url });
@@ -198,7 +205,7 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
         }
     }
 
-    return <View style={{ width: '100%', marginBottom: 48, marginTop: 12 }} >
+    return <View style={route.name !== "LiveStreamScreen" ? { width: '100%', marginBottom: 48, marginTop: 12 } : { width: '100%', marginBottom: 48, marginTop: 0, flex: 1 }} >
         {markupArray.map(item => { return item })}
     </View>
 

--- a/components/teaching/notes/NoteReader.tsx
+++ b/components/teaching/notes/NoteReader.tsx
@@ -203,7 +203,7 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
         }
     }
 
-    return <View style={route.name !== "LiveStreamScreen" ? { width: '100%', marginBottom: 48, marginTop: 12 } : { width: '100%', marginBottom: 48, marginTop: 0, flex: 1 }} >
+    return <View style={route.name !== "LiveStreamScreen" ? { width: '100%', marginBottom: 48, marginTop: 12 } : { width: '100%', marginBottom: 48, marginTop: -12 }} >
         {markupArray.map(item => { return item })}
     </View>
 

--- a/components/teaching/notes/NoteReader.tsx
+++ b/components/teaching/notes/NoteReader.tsx
@@ -142,10 +142,13 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
                 const data = entityMap[entity.key];
                 switch (data.type) {
                     case "IMAGE":
-                        if (numberOfImages === 0)
-                            markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
+                        if (numberOfImages === 0){
+                            if(route.name!=="LiveStreamScreen") {//this removes the first header image when coming from livestreamscreen. 
+                                markupArray.push(<HeaderImage data={data.data} key={'header image 0'} />)
+                            }
+                        }
                         else
-                            markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)
+                            markupArray.push(<CustomImage styles={styles} noteId={noteId} block={block} mode={mode} data={data.data} key={block.key + type} type={type} />)                       
                         numberOfImages++
 
                         break;
@@ -203,7 +206,7 @@ export default function NoteReader({ blocks, entityMap, mode, fontScale, type, o
         }
     }
 
-    return <View style={route.name !== "LiveStreamScreen" ? { width: '100%', marginBottom: 48, marginTop: 12 } : { width: '100%', marginBottom: 48, marginTop: -12 }} >
+    return <View style={route.name === "LiveStreamScreen" &&  type === "notes" ? { width: '100%', marginBottom: 48, marginTop: -18 } : { width: '100%', marginBottom: 48, marginTop: 12 }} >
         {markupArray.map(item => { return item })}
     </View>
 

--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -18,6 +18,7 @@ import HighlightScreen from '../screens/HighlightScreen';
 import DateRangeSelectScreen from '../screens/DateRangeSelectScreen';
 import SermonLandingScreen from '../screens/SermonLandingScreen';
 import { CommentDataType } from '../services/API';
+import LiveStreamScreen from "../screens/LiveStreamScreen";
 
 export type MainStackParamList = {
   Main: undefined | {
@@ -38,11 +39,12 @@ export type MainStackParamList = {
   HighlightScreen: { highlights: any[], nextToken: string | undefined };
   DateRangeSelectScreen: undefined;
   SermonLandingScreen: { item: any };
+  LiveStreamScreen: undefined;
   CommentScreen: {
     key: string,
     noteId: string,
     commentType: CommentDataType,
-    noteType: 'notes' | 'questions', t
+    noteType: 'notes' | 'questions',
     extSnippet?: string,
     imageUri?: string
   } | {
@@ -72,6 +74,7 @@ export default function NavigationRoot(): JSX.Element {
       <Main.Screen name="DateRangeSelectScreen" component={DateRangeSelectScreen} />
       <Main.Screen name="SermonLandingScreen" component={SermonLandingScreen} />
       <Main.Screen name="CommentScreen" component={CommentScreen} />
+      <Main.Screen name="LiveStreamScreen" component={LiveStreamScreen} />
     </Main.Navigator>
   )
 }

--- a/navigation/MainTabNavigator.tsx
+++ b/navigation/MainTabNavigator.tsx
@@ -24,11 +24,14 @@ import { Theme } from '../Theme.style';
 import { StyleSheet } from 'react-native';
 import MediaContext from '../contexts/MediaContext';
 import { GetVideoByVideoTypeQuery } from '../services/API';
+import LiveStreamScreen from '../screens/LiveStreamScreen';
 
 export type HomeStackParamList = {
   HomeScreen: undefined;
   EventDetailsScreen: { item: any };
   AnnouncementDetailsScreen: { item: any };
+  NotesScreen: { date: string }
+  LiveStreamScreen: undefined;
 }
 
 const Home = createStackNavigator<HomeStackParamList>();
@@ -39,6 +42,7 @@ function HomeStack() {
       <Home.Screen name="HomeScreen" component={HomeScreen} />
       <Home.Screen name="EventDetailsScreen" component={EventDetailsScreen} />
       <Home.Screen name="AnnouncementDetailsScreen" component={AnnouncementDetailsScreen} />
+      <Home.Screen name="LiveStreamScreen" component={LiveStreamScreen} />
     </Home.Navigator>
   )
 }

--- a/navigation/MainTabNavigator.tsx
+++ b/navigation/MainTabNavigator.tsx
@@ -30,7 +30,6 @@ export type HomeStackParamList = {
   HomeScreen: undefined;
   EventDetailsScreen: { item: any };
   AnnouncementDetailsScreen: { item: any };
-  NotesScreen: { date: string }
   LiveStreamScreen: undefined;
 }
 

--- a/screens/AnnouncementBar.tsx
+++ b/screens/AnnouncementBar.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Theme } from '../Theme.style';
+import { View, Text } from "react-native"
+import { StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { MainStackParamList } from '../navigation/AppNavigator';
+import { StackNavigationProp } from '@react-navigation/stack';
+
+interface Props {
+    message: string;
+}
+export default function AnnouncementBar(props: Props): JSX.Element {
+
+    const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
+    const style = StyleSheet.create({
+        container: {
+            backgroundColor: Theme.colors.yellow,
+            padding: 16,
+            position: "relative",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            lineHeight: 2,
+            zIndex: 1,
+            marginBottom: -33
+        },
+        message: {
+            color: Theme.colors.black,
+            fontSize: 16
+        }
+
+    })
+    return (
+        <View style={style.container}>
+            <Text onPress={() => navigation.push('LiveStreamScreen')} style={style.message}>{props.message}</Text>
+        </View>
+
+    )
+}
+

--- a/screens/AnnouncementBar.tsx
+++ b/screens/AnnouncementBar.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Theme } from '../Theme.style';
-import { View, Text } from "react-native"
+import { Text } from "react-native"
 import { StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { MainStackParamList } from '../navigation/AppNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 interface Props {
     message: string;
@@ -22,18 +23,20 @@ export default function AnnouncementBar(props: Props): JSX.Element {
             alignItems: "flex-start",
             lineHeight: 2,
             zIndex: 1,
-            marginBottom: -33
         },
         message: {
             color: Theme.colors.black,
-            fontSize: 16
+            fontSize: 16,
+            fontFamily: Theme.fonts.fontFamilyMedium,
+            fontWeight: "normal",
+            lineHeight: 24,
         }
 
     })
     return (
-        <View style={style.container}>
-            <Text onPress={() => navigation.push('LiveStreamScreen')} style={style.message}>{props.message}</Text>
-        </View>
+        <TouchableOpacity style={style.container} onPress={() => navigation.push('LiveStreamScreen')}>
+            <Text style={style.message}>{props.message}</Text>
+        </TouchableOpacity >
 
     )
 }

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -49,12 +49,12 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
+    const today = moment().format('YYYY:MM:DD') // this needs to be the current date and must account for timezone!
     const loadLiveStreams = async () => {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = "06:00"//moment().format('HH:mm') // needs timezone
+          const rightNow = moment().format('HH:mm') // needs timezone
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
           if (showTime) {
             setLive(true)
@@ -104,7 +104,7 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   return (
     <Container>
       <LocationSelectHeader>Home</LocationSelectHeader>
-      {live ? <AnnouncementBar message={"We are live! Come check out our livestream."} ></AnnouncementBar> : null}
+      {true ? <AnnouncementBar message={"We are live! Come check out our livestream."} ></AnnouncementBar> : null}
       <Content style={{ backgroundColor: Theme.colors.background, flex: 1 }}>
 
         <View style={[style.categoryContainer, { paddingBottom: 48 }]}>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -49,12 +49,12 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const today = moment().format("2020-10-25")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
+    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const loadLiveStreams = async () => {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+          const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
           if (showTime) {
             if (rightNow >= event.videoStartTime && rightNow <= event.endTime) setLive(true)

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -212,21 +212,6 @@ const listLivestreams = /* GraphQL */ `
         endTime
         prerollYoutubeId
         liveYoutubeId
-        showChat
-        showKids
-        menu {
-          title
-          link
-          linkType
-        }
-        zoom {
-          title
-          link
-        }
-        titles
-        homepageLink
-        createdAt
-        updatedAt
       }
       nextToken
     }

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -49,12 +49,12 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
+    const today = moment().format("2020-10-25")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const loadLiveStreams = async () => {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+          const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
           if (showTime) {
             if (rightNow >= event.videoStartTime && rightNow <= event.endTime) setLive(true)

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -55,7 +55,7 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = "15:50"//moment().format('HH:mm') // needs timezone
+          const rightNow = "09:50"//moment().format('HH:mm') // needs timezone
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
           console.log(event.endTime)
           if (showTime) {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -113,9 +113,6 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
             <WhiteButton outlined label="Send Question" style={{ height: 56 }} onPress={sendQuestion}></WhiteButton>
           </View>
         </View>
-        <View>
-
-        </View>
         {location?.locationData?.locationId !== "unknown" || location?.locationData.locationName !== "unknown" ?
           <View style={style.categoryContainer}>
             {isLoading ? <ActivityIndicator /> : <>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -23,7 +23,6 @@ import InstagramService, { InstagramData } from '../services/Instagram';
 import InstagramFeed from '../components/home/InstagramFeed';
 import * as Linking from 'expo-linking';
 import AllButton from '../components/buttons/AllButton';
-import { NavigationHelpersContext } from '@react-navigation/native';
 import AnnouncementBar from "../screens/AnnouncementBar"
 import { runGraphQLQuery } from "../services/ApiService"
 const style = StyleSheet.create({
@@ -57,7 +56,6 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
         liveStreamsResult.listLivestreams.items.map((event: any) => {
           const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
-          console.log(event.endTime)
           if (showTime) {
             if (rightNow >= event.videoStartTime && rightNow <= event.endTime) setLive(true)
             setpreLive(true)

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -50,12 +50,12 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
+    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const loadLiveStreams = async () => {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = "09:50"//moment().format('HH:mm') // needs timezone
+          const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
           console.log(event.endTime)
           if (showTime) {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -41,7 +41,8 @@ interface Params {
 export default function HomeScreen({ navigation }: Params): JSX.Element {
 
   const location = useContext(LocationContext);
-  const [live, setLive] = useState(false)
+  const [preLive, setpreLive] = useState(false)
+  const [live, setLive] = useState(false);
   //const [announcements, setAnnouncements] = useState<any>([]);
   const [events, setEvents] = useState<any>([]);
   const [images, setImages] = useState<InstagramData>([]);
@@ -49,16 +50,17 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const today = moment().format('YYYY:MM:DD') // this needs to be the current date and must account for timezone!
+    const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
     const loadLiveStreams = async () => {
       try {
         const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
         liveStreamsResult.listLivestreams.items.map((event: any) => {
-          const rightNow = moment().format('HH:mm') // needs timezone
+          const rightNow = "15:50"//moment().format('HH:mm') // needs timezone
           const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
+          console.log(event.endTime)
           if (showTime) {
-            setLive(true)
-            console.log("setting live to true")
+            if (rightNow >= event.videoStartTime && rightNow <= event.endTime) setLive(true)
+            setpreLive(true)
           }
         })
       }
@@ -104,7 +106,7 @@ export default function HomeScreen({ navigation }: Params): JSX.Element {
   return (
     <Container>
       <LocationSelectHeader>Home</LocationSelectHeader>
-      {true ? <AnnouncementBar message={"We are live! Come check out our livestream."} ></AnnouncementBar> : null}
+      {live || preLive ? <AnnouncementBar message={preLive ? !live ? "We will be going live soon!" : "We are live now!" : ""}></AnnouncementBar> : null}
       <Content style={{ backgroundColor: Theme.colors.background, flex: 1 }}>
 
         <View style={[style.categoryContainer, { paddingBottom: 48 }]}>

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -56,8 +56,8 @@ const style = StyleSheet.create({
 })
 
 interface Props {
-    navigation: StackNavigationProp<HomeStackParamList | MainStackParamList, "NotesScreen">;
-    route: RouteProp<HomeStackParamList, 'NotesScreen'>;
+    navigation: StackNavigationProp<MainStackParamList, "NotesScreen">;
+    route: RouteProp<MainStackParamList, 'NotesScreen'>;
 }
 
 type LiveEvent = {
@@ -76,7 +76,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     //const mediaContext = useContext(MediaContext);
     const playerRef = useRef<YoutubeIframeRef>(null);
     const deviceWidth = Dimensions.get('window').width
-    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
+    const today = moment().format("2020-10-25")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const handleVideoReady = () => {
         playerRef?.current?.seekTo(0,true);
     }
@@ -86,7 +86,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
             try {
                 const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
                 liveStreamsResult.listLivestreams.items.map((event: LiveEvent) => {
-                    const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+                    const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
                     const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
                     if (showTime) {
                         setcurrentEvent(event)
@@ -104,7 +104,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
         const interval = setInterval(() => {
             const start = currentEvent?.videoStartTime
             const end = currentEvent?.endTime
-            const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+            const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
             //console.log(videoStartTime is ${currentEvent?.videoStartTime} endTime is ${currentEvent?.endTime} and current time is ${rightNow}`)
             if (start && end) {
                 const showTime = rightNow >= start && rightNow <= end

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -110,7 +110,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
         }, 1000);
         return () => clearInterval(interval);
     }, [currentEvent]);
-
+    // this page needs to be unmounted when navigating to teaching
     return (
         <Container>
             <Content style={style.content}>

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useState } from 'react';
+import { Theme, Style, HeaderStyle } from '../Theme.style';
+import { Container, Text, Button, Icon, Content, Left, Right, Header, Body, View } from 'native-base';
+import IconButton from '../components/buttons/IconButton';
+import moment from 'moment';
+import MediaContext from '../contexts/MediaContext';
+import { StatusBar, StyleSheet, Dimensions } from 'react-native';
+import { HomeStackParamList } from '../navigation/MainTabNavigator';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RouteProp } from '@react-navigation/native';
+import { useContext } from 'react';
+import YoutubePlayer, { YoutubeIframeRef } from 'react-native-youtube-iframe';
+import { useRef } from 'react';
+import { runGraphQLQuery } from "../services/ApiService"
+import NotesScreen from './NotesScreen';
+const style = StyleSheet.create({
+    content: {
+        ...Style.cardContainer, ...{
+            backgroundColor: Theme.colors.black,
+            padding: 0,
+        },
+    },
+    player: {
+        height: Math.round(Dimensions.get('window').width * (9 / 16)),
+        marginBottom: 8
+    },
+    header: Style.header,
+    headerLeft: {
+        flexGrow: 0,
+        flexShrink: 0,
+        flexBasis: 50
+    },
+    headerBody: {
+        flexGrow: 3,
+        justifyContent: "center",
+    },
+    headerRight: {
+        flexGrow: 0,
+        flexShrink: 0,
+        flexBasis: 50
+    },
+    headerTitle: {
+        ...HeaderStyle.title, ...{
+            width: "100%",
+        }
+    },
+    title: {
+        ...Style.title, ...{
+            padding: 16,
+        }
+    },
+    body: {
+        ...Style.body, ...{
+            marginBottom: 5,
+        }
+    },
+})
+
+interface Props {
+    navigation: StackNavigationProp<HomeStackParamList>;
+    route: RouteProp<HomeStackParamList, 'LiveStreamScreen'>;
+}
+
+
+export default function LiveStreamScreen(props: Props): JSX.Element {
+    const [currentEvent, setcurrentEvent]: any = useState(null);
+    const [showTime, setshowTime] = useState(false);
+    const mediaContext = useContext(MediaContext);
+    const playerRef = useRef<YoutubeIframeRef>(null);
+    const deviceWidth = Dimensions.get('window').width
+    const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
+    const handleVideoReady = () => {
+        playerRef?.current?.seekTo(mediaContext.media.videoTime, true);
+    }
+    useEffect(() => {
+        console.log("App has loaded")
+        const loadLiveStreams = async () => {
+            try {
+                const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
+                liveStreamsResult.listLivestreams.items.map((event: any) => {
+                    const rightNow = "09:49"//moment().format('HH:mm') // needs timezone
+                    console.log(event)
+                    const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
+                    if (showTime) {
+                        setcurrentEvent(event)
+                    }
+                })
+            }
+            catch (error) {
+                console.log(error)
+            }
+        }
+        loadLiveStreams();
+    }, [])
+    useEffect(() => {
+        console.log("Checking if its showtime")
+        const start = currentEvent?.videoStartTime
+        const end = currentEvent?.endTime
+        const rightNow = "09:50"//moment().format('HH:mm') // needs timezone
+        console.log(`VideoStartTime is ${currentEvent?.videoStartTime} endTime is ${currentEvent?.endTime} and current time is ${rightNow}`)
+        if (start && end) {
+            const showTime = rightNow >= start && rightNow <= end
+            if (showTime) {
+                console.log("ShowLive")
+                setshowTime(true)
+            }
+        }
+        else {
+            setshowTime(false)
+        }
+    }, [currentEvent])
+    return (
+        <Container>
+            <Header style={style.header}>
+                <StatusBar backgroundColor={Theme.colors.black} barStyle="light-content" />
+                <Left style={style.headerLeft}>
+                    <Button transparent onPress={() => props.navigation.goBack()}>
+                        <Icon name='close' />
+                    </Button>
+                </Left>
+                <Body style={style.headerBody}>
+                    <Text style={style.headerTitle}></Text>
+                </Body>
+                <Right style={style.headerRight}>
+                    {/*Share modal here */}
+                </Right>
+            </Header>
+            <Content style={style.content}>
+                <Text style={style.title}>{showTime ? "Livestream" : "Livestream Pre-roll"}</Text>
+                <View style={style.player}>
+                    {showTime ?
+                        <>
+                            <YoutubePlayer
+                                ref={playerRef}
+                                onReady={handleVideoReady}
+                                forceAndroidAutoplay
+                                height={Math.round(deviceWidth * (9 / 16))}
+                                width={Math.round(deviceWidth)}
+                                videoId={currentEvent ? currentEvent.liveYoutubeId as string : ""}
+                                play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
+                                initialPlayerParams={{ modestbranding: true }}
+                            />
+                        </> : <>
+                            <YoutubePlayer
+                                ref={playerRef}
+                                onReady={handleVideoReady}
+                                forceAndroidAutoplay
+                                height={Math.round(deviceWidth * (9 / 16))}
+                                width={Math.round(deviceWidth)}
+                                videoId={currentEvent ? currentEvent.prerollYoutubeId as string : ""}
+                                play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
+                                initialPlayerParams={{ modestbranding: true }}
+                            /></>}
+                </View >
+                <IconButton style={{ padding: 16 }} rightArrow icon={Theme.icons.white.notes} label="Notes" onPress={() => props.navigation.push('NotesScreen', { date: moment().format('2020-10-25') })} />
+            </Content>
+        </Container>
+    )
+}
+
+const listLivestreams = /* GraphQL */ `
+  query ListLivestreams(
+    $filter: ModelLivestreamFilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listLivestreams(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        date
+        startTime
+        videoStartTime
+        endTime
+        prerollYoutubeId
+        liveYoutubeId
+        showChat
+        showKids
+        menu {
+          title
+          link
+          linkType
+        }
+        zoom {
+          title
+          link
+        }
+        titles
+        homepageLink
+        createdAt
+        updatedAt
+      }
+      nextToken
+    }
+  }
+`;

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -124,7 +124,6 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
         <Container style={{ backgroundColor: "black" }}>
             <View style={style.player}>
                 {showTime ?
-                    <>
                         <YoutubePlayer
                             volume={100}
                             ref={playerRef}
@@ -135,8 +134,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                             videoId={currentEvent ? currentEvent.liveYoutubeId as string : ""}
                             play={true}
                             initialPlayerParams={{ modestbranding: true }}
-                        />
-                    </> : <>
+                        /> : 
                         <YoutubePlayer
                             volume={100}
                             ref={playerRef}
@@ -147,8 +145,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                             videoId={currentEvent ? currentEvent.prerollYoutubeId as string : ""}
                             play={true}
                             initialPlayerParams={{ modestbranding: true }}
-                        />
-                    </>}
+                        />}
             </View >
             <NotesScreen today={today} navigation={props.navigation} route={props.route}></NotesScreen>
         </Container>

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -76,7 +76,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     //const mediaContext = useContext(MediaContext);
     const playerRef = useRef<YoutubeIframeRef>(null);
     const deviceWidth = Dimensions.get('window').width
-    const today = moment().format("2020-10-25")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
+    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const handleVideoReady = () => {
         playerRef?.current?.seekTo(0,true);
     }
@@ -86,7 +86,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
             try {
                 const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
                 liveStreamsResult.listLivestreams.items.map((event: LiveEvent) => {
-                    const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+                    const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
                     const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
                     if (showTime) {
                         setcurrentEvent(event)
@@ -104,7 +104,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
         const interval = setInterval(() => {
             const start = currentEvent?.videoStartTime
             const end = currentEvent?.endTime
-            const rightNow = moment().format("09:50")//moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+            const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
             //console.log(videoStartTime is ${currentEvent?.videoStartTime} endTime is ${currentEvent?.endTime} and current time is ${rightNow}`)
             if (start && end) {
                 const showTime = rightNow >= start && rightNow <= end

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Theme, Style, HeaderStyle } from '../Theme.style';
 import { Container, Text, Button, Icon, Content, Left, Right, Header, Body, View } from 'native-base';
-import IconButton from '../components/buttons/IconButton';
+//import IconButton from '../components/buttons/IconButton';
 import moment from 'moment';
 import MediaContext from '../contexts/MediaContext';
-import { StatusBar, StyleSheet, Dimensions } from 'react-native';
+import { StyleSheet, Dimensions } from 'react-native';
 import { HomeStackParamList } from '../navigation/MainTabNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
@@ -14,11 +14,12 @@ import { useRef } from 'react';
 import { runGraphQLQuery } from "../services/ApiService"
 import NotesScreen from './NotesScreen';
 import { MainStackParamList } from 'navigation/AppNavigator';
+
 const style = StyleSheet.create({
     content: {
         ...Style.cardContainer, ...{
             backgroundColor: Theme.colors.black,
-            padding: 0,
+            padding: 0
         },
     },
     player: {
@@ -51,14 +52,13 @@ const style = StyleSheet.create({
     },
     body: {
         ...Style.body, ...{
-            marginBottom: 5,
-        }
+        },
     },
 })
 
 interface Props {
-    navigation: StackNavigationProp<HomeStackParamList>;
-    route: RouteProp<HomeStackParamList, 'LiveStreamScreen'>;
+    navigation: StackNavigationProp<HomeStackParamList | MainStackParamList, "NotesScreen">;
+    route: RouteProp<HomeStackParamList, 'NotesScreen'>;
 }
 
 export default function LiveStreamScreen(props: Props): JSX.Element {
@@ -113,22 +113,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
 
     return (
         <Container>
-            <Header style={style.header}>
-                <StatusBar backgroundColor={Theme.colors.black} barStyle="light-content" />
-                <Left style={style.headerLeft}>
-                    <Button transparent onPress={() => props.navigation.goBack()}>
-                        <Icon name='close' />
-                    </Button>
-                </Left>
-                <Body style={style.headerBody}>
-                    <Text style={style.headerTitle}>{showTime === true ? "Livestream" : "Livestream Pre-roll"}</Text>
-                </Body>
-                <Right style={style.headerRight}>
-                    {/*Share modal here */}
-                </Right>
-            </Header>
             <Content style={style.content}>
-
                 <View style={style.player}>
                     {showTime ?
                         <>
@@ -155,8 +140,12 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                             />
                         </>}
                 </View >
-                <IconButton style={{ marginTop: 20, padding: 16 }} rightArrow icon={Theme.icons.white.notes} label="Notes" onPress={() => props.navigation.push('NotesScreen', { date: moment().format('YYYY-MM-DD') })} />
+
             </Content>
+            <Content style={{ zIndex: 100, marginTop: -60 }}>
+                <NotesScreen today={moment().format('2020-10-25')} navigation={props.navigation} route={props.route}></NotesScreen>
+            </Content>
+
         </Container>
     )
 }

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -69,18 +69,17 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     const playerRef = useRef<YoutubeIframeRef>(null);
     const deviceWidth = Dimensions.get('window').width
     const [isLoading, setisLoading] = useState(true);
-    const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
+    const today = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('YYYY-MM-DD')
     const handleVideoReady = () => {
         playerRef?.current?.seekTo(mediaContext.media.videoTime, true);
     }
 
     useEffect(() => {
-        console.log(Dimensions.get('window').height)
         const loadLiveStreams = async () => {
             try {
                 const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
                 liveStreamsResult.listLivestreams.items.map((event: any) => {
-                    const rightNow = "09:50"//moment().format('HH:mm') // needs timezone
+                    const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
                     const showTime = event?.startTime && event?.endTime && rightNow >= event.startTime && rightNow <= event.endTime
                     if (showTime) {
                         setcurrentEvent(event)
@@ -99,12 +98,12 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
         const interval = setInterval(() => {
             const start = currentEvent?.videoStartTime
             const end = currentEvent?.endTime
-            const rightNow = "09:50"//moment().format('HH:mm') // needs timezone
-            console.log(`VideoStartTime is ${currentEvent?.videoStartTime} endTime is ${currentEvent?.endTime} and current time is ${rightNow}`)
+            const rightNow = moment().utcOffset(moment().isDST() ? '-0400' : '-0500').format('HH:mm')
+            //console.log(`VideoStartTime is ${currentEvent?.videoStartTime} endTime is ${currentEvent?.endTime} and current time is ${rightNow}`)
             if (start && end) {
                 const showTime = rightNow >= start && rightNow <= end
                 if (showTime) {
-                    console.log("ShowLive")
+                    //console.log("ShowLive")
                     setshowTime(true)
                 }
             }
@@ -117,37 +116,36 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     // this page needs to be unmounted when navigating to teaching
     return (
         <Container style={{ backgroundColor: "black" }}>
-            <Content style={style.content}>
-                <View style={style.player}>
-                    {showTime ?
-                        <>
-                            <YoutubePlayer
-                                ref={playerRef}
-                                onReady={handleVideoReady}
-                                forceAndroidAutoplay
-                                height={Math.round(deviceWidth * (9 / 16))}
-                                width={Math.round(deviceWidth)}
-                                videoId={currentEvent ? currentEvent.liveYoutubeId as string : ""}
-                                play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
-                                initialPlayerParams={{ modestbranding: true }}
-                            />
-                        </> : <>
-                            <YoutubePlayer
-                                ref={playerRef}
-                                onReady={handleVideoReady}
-                                forceAndroidAutoplay
-                                height={Math.round(deviceWidth * (9 / 16))}
-                                width={Math.round(deviceWidth)}
-                                videoId={currentEvent ? currentEvent.prerollYoutubeId as string : ""}
-                                play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
-                                initialPlayerParams={{ modestbranding: true }}
-                            />
-                        </>}
-                </View >
-            </Content>
 
-            <NotesScreen today={moment().format('2020-10-25')} navigation={props.navigation} route={props.route}></NotesScreen>
-
+            <View style={style.player}>
+                {showTime ?
+                    <>
+                        <YoutubePlayer
+                            volume={100}
+                            ref={playerRef}
+                            onReady={handleVideoReady}
+                            forceAndroidAutoplay
+                            height={Math.round(deviceWidth * (9 / 16))}
+                            width={Math.round(deviceWidth)}
+                            videoId={currentEvent ? currentEvent.liveYoutubeId as string : ""}
+                            play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
+                            initialPlayerParams={{ modestbranding: true }}
+                        />
+                    </> : <>
+                        <YoutubePlayer
+                            volume={100}
+                            ref={playerRef}
+                            onReady={handleVideoReady}
+                            forceAndroidAutoplay
+                            height={Math.round(deviceWidth * (9 / 16))}
+                            width={Math.round(deviceWidth)}
+                            videoId={currentEvent ? currentEvent.prerollYoutubeId as string : ""}
+                            play={mediaContext.media.playing && Boolean(mediaContext.media.video)}
+                            initialPlayerParams={{ modestbranding: true }}
+                        />
+                    </>}
+            </View >
+            <NotesScreen today={today} navigation={props.navigation} route={props.route}></NotesScreen>
         </Container>
     )
 }

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -14,12 +14,13 @@ import { useRef } from 'react';
 import { runGraphQLQuery } from "../services/ApiService"
 import NotesScreen from './NotesScreen';
 import { MainStackParamList } from 'navigation/AppNavigator';
+import ActivityIndicator from '../components/ActivityIndicator';
 
 const style = StyleSheet.create({
     content: {
         ...Style.cardContainer, ...{
             backgroundColor: Theme.colors.black,
-            padding: 0
+            padding: 0,
         },
     },
     player: {
@@ -67,12 +68,14 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     const mediaContext = useContext(MediaContext);
     const playerRef = useRef<YoutubeIframeRef>(null);
     const deviceWidth = Dimensions.get('window').width
+    const [isLoading, setisLoading] = useState(true);
     const today = moment().format('2020-10-25') // this needs to be the current date and must account for timezone!
     const handleVideoReady = () => {
         playerRef?.current?.seekTo(mediaContext.media.videoTime, true);
     }
 
     useEffect(() => {
+        console.log(Dimensions.get('window').height)
         const loadLiveStreams = async () => {
             try {
                 const liveStreamsResult = await runGraphQLQuery({ query: listLivestreams, variables: { filter: { date: { eq: today } } } })
@@ -89,6 +92,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
             }
         }
         loadLiveStreams();
+        setisLoading(false)
     }, [])
 
     useEffect(() => {
@@ -112,7 +116,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
     }, [currentEvent]);
     // this page needs to be unmounted when navigating to teaching
     return (
-        <Container>
+        <Container style={{ backgroundColor: "black" }}>
             <Content style={style.content}>
                 <View style={style.player}>
                     {showTime ?
@@ -140,11 +144,9 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                             />
                         </>}
                 </View >
+            </Content>
 
-            </Content>
-            <Content style={{ zIndex: 100, marginTop: -60 }}>
-                <NotesScreen today={moment().format('2020-10-25')} navigation={props.navigation} route={props.route}></NotesScreen>
-            </Content>
+            <NotesScreen today={moment().format('2020-10-25')} navigation={props.navigation} route={props.route}></NotesScreen>
 
         </Container>
     )

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -13,6 +13,7 @@ import YoutubePlayer, { YoutubeIframeRef } from 'react-native-youtube-iframe';
 import { useRef } from 'react';
 import { runGraphQLQuery } from "../services/ApiService"
 import NotesScreen from './NotesScreen';
+import { MainStackParamList } from 'navigation/AppNavigator';
 const style = StyleSheet.create({
     content: {
         ...Style.cardContainer, ...{
@@ -60,11 +61,9 @@ interface Props {
     route: RouteProp<HomeStackParamList, 'LiveStreamScreen'>;
 }
 
-
 export default function LiveStreamScreen(props: Props): JSX.Element {
     const [currentEvent, setcurrentEvent]: any = useState(null);
     const [showTime, setshowTime]: any = useState(null);
-    const [currentTime, setcurrentTime] = useState(moment().format("HH:mm"))
     const mediaContext = useContext(MediaContext);
     const playerRef = useRef<YoutubeIframeRef>(null);
     const deviceWidth = Dimensions.get('window').width
@@ -108,8 +107,6 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
             else {
                 setshowTime(false)
             }
-
-
         }, 1000);
         return () => clearInterval(interval);
     }, [currentEvent]);
@@ -124,7 +121,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                     </Button>
                 </Left>
                 <Body style={style.headerBody}>
-                    <Text style={style.headerTitle}>{showTime === null ? "" : showTime === true ? "Livestream" : "Livestream Pre-roll"}</Text>
+                    <Text style={style.headerTitle}>{showTime === true ? "Livestream" : "Livestream Pre-roll"}</Text>
                 </Body>
                 <Right style={style.headerRight}>
                     {/*Share modal here */}

--- a/screens/LiveStreamScreen.tsx
+++ b/screens/LiveStreamScreen.tsx
@@ -3,7 +3,6 @@ import { Theme, Style, HeaderStyle } from '../Theme.style';
 import { Container, View } from 'native-base';
 import moment from 'moment';
 import { StyleSheet, Dimensions } from 'react-native';
-import { HomeStackParamList } from '../navigation/MainTabNavigator';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
 //import { useContext } from 'react';
@@ -147,7 +146,7 @@ export default function LiveStreamScreen(props: Props): JSX.Element {
                             initialPlayerParams={{ modestbranding: true }}
                         />}
             </View >
-            <NotesScreen today={today} navigation={props.navigation} route={props.route}></NotesScreen>
+            <NotesScreen fromLiveStream={true} today={today} navigation={props.navigation} route={props.route}></NotesScreen>
         </Container>
     )
 }

--- a/screens/NotesScreen.tsx
+++ b/screens/NotesScreen.tsx
@@ -336,7 +336,7 @@ export default function NotesScreen({ route, navigation, today }: Params): JSX.E
         }
     }
 
-    return <View style={{ height: 2500, marginTop: -58 }}>
+    return <View style={{ flex: 1 }}>
         {notes.blocks.length > 0 ?
             <Swiper ref={ref} loop={false} showsPagination={false} showsButtons={false} onIndexChanged={(index) => setNotesMode(index === 0 ? 'notes' : 'questions')} >
                 <Content style={[style.content, { backgroundColor: mode === 'dark' ? 'black' : Theme.colors.grey6 }]} key='notes'>

--- a/screens/NotesScreen.tsx
+++ b/screens/NotesScreen.tsx
@@ -130,8 +130,8 @@ const style = StyleSheet.create({
 type VerseType = NonNullable<NonNullable<GetNotesQuery['getNotes']>['verses']>['items'];
 
 interface Params {
-    navigation: StackNavigationProp<MainStackParamList | HomeStackParamList, 'NotesScreen'>
-    route: RouteProp<MainStackParamList | HomeStackParamList, 'NotesScreen' | 'LiveStreamScreen'>
+    navigation: StackNavigationProp<MainStackParamList , 'NotesScreen'>
+    route: RouteProp<MainStackParamList , 'NotesScreen'>
     today: string;
 }
 

--- a/screens/NotesScreen.tsx
+++ b/screens/NotesScreen.tsx
@@ -19,6 +19,7 @@ import { GetCommentsByOwnerQuery, GetCommentsByOwnerQueryVariables, GetNotesQuer
 import CommentContext from '../contexts/CommentContext';
 import OpenVerseModal from '../components/modals/OpenVerseModal';
 import UserContext from '../contexts/UserContext';
+import { HomeStackParamList } from 'navigation/MainTabNavigator';
 
 interface Style {
     content: any;
@@ -129,13 +130,13 @@ const style = StyleSheet.create({
 type VerseType = NonNullable<NonNullable<GetNotesQuery['getNotes']>['verses']>['items'];
 
 interface Params {
-    navigation: StackNavigationProp<MainStackParamList, 'NotesScreen'>
-    route: RouteProp<MainStackParamList, 'NotesScreen'>
+    navigation: StackNavigationProp<MainStackParamList | HomeStackParamList, 'NotesScreen'>
+    route: RouteProp<MainStackParamList | HomeStackParamList, 'NotesScreen' | 'LiveStreamScreen'>
+    today: string;
 }
 
-export default function NotesScreen({ route, navigation }: Params): JSX.Element {
-    const date = route.params?.date;
-
+export default function NotesScreen({ route, navigation, today }: Params): JSX.Element {
+    const date = route?.params?.date || today;
     const [notes, setNotes] = useState({ blocks: [], entityMap: {} });
     const [questions, setQuestions] = useState({ blocks: [], entityMap: {} });
     const [notesMode, setNotesMode] = useState("notes");
@@ -335,14 +336,14 @@ export default function NotesScreen({ route, navigation }: Params): JSX.Element 
         }
     }
 
-    return <View style={{ flex: 1 }}>
+    return <View style={{ height: 2500, marginTop: -58 }}>
         {notes.blocks.length > 0 ?
             <Swiper ref={ref} loop={false} showsPagination={false} showsButtons={false} onIndexChanged={(index) => setNotesMode(index === 0 ? 'notes' : 'questions')} >
                 <Content style={[style.content, { backgroundColor: mode === 'dark' ? 'black' : Theme.colors.grey6 }]} key='notes'>
-                    <NoteReader noteId={noteId} blocks={notes.blocks} date={date} verses={verses} entityMap={notes.entityMap} mode={mode} fontScale={fontScale} type='notes' openVerseCallback={handleOpenVerse} />
+                    <NoteReader route={route} noteId={noteId} blocks={notes.blocks} date={date} verses={verses} entityMap={notes.entityMap} mode={mode} fontScale={fontScale} type='notes' openVerseCallback={handleOpenVerse} />
                 </Content>
                 <Content style={[style.content, { backgroundColor: mode === 'dark' ? 'black' : Theme.colors.grey6 }]} key='questions' >
-                    <NoteReader noteId={noteId} blocks={questions.blocks} date={date} verses={verses} entityMap={questions.entityMap} mode={mode} fontScale={fontScale} type='questions' openVerseCallback={handleOpenVerse} />
+                    <NoteReader route={route} noteId={noteId} blocks={questions.blocks} date={date} verses={verses} entityMap={questions.entityMap} mode={mode} fontScale={fontScale} type='questions' openVerseCallback={handleOpenVerse} />
                 </Content>
             </Swiper> : <ActivityIndicator />
         }

--- a/screens/NotesScreen.tsx
+++ b/screens/NotesScreen.tsx
@@ -19,7 +19,6 @@ import { GetCommentsByOwnerQuery, GetCommentsByOwnerQueryVariables, GetNotesQuer
 import CommentContext from '../contexts/CommentContext';
 import OpenVerseModal from '../components/modals/OpenVerseModal';
 import UserContext from '../contexts/UserContext';
-import { HomeStackParamList } from 'navigation/MainTabNavigator';
 
 interface Style {
     content: any;
@@ -133,9 +132,10 @@ interface Params {
     navigation: StackNavigationProp<MainStackParamList , 'NotesScreen'>
     route: RouteProp<MainStackParamList , 'NotesScreen'>
     today: string;
+    fromLiveStream: boolean | undefined
 }
 
-export default function NotesScreen({ route, navigation, today }: Params): JSX.Element {
+export default function NotesScreen({ route, navigation, today, fromLiveStream }: Params): JSX.Element {
     const date = route?.params?.date || today;
     const [notes, setNotes] = useState({ blocks: [], entityMap: {} });
     const [questions, setQuestions] = useState({ blocks: [], entityMap: {} });
@@ -340,10 +340,10 @@ export default function NotesScreen({ route, navigation, today }: Params): JSX.E
         {notes.blocks.length > 0 ?
             <Swiper ref={ref} loop={false} showsPagination={false} showsButtons={false} onIndexChanged={(index) => setNotesMode(index === 0 ? 'notes' : 'questions')} >
                 <Content style={[style.content, { backgroundColor: mode === 'dark' ? 'black' : Theme.colors.grey6 }]} key='notes'>
-                    <NoteReader route={route} noteId={noteId} blocks={notes.blocks} date={date} verses={verses} entityMap={notes.entityMap} mode={mode} fontScale={fontScale} type='notes' openVerseCallback={handleOpenVerse} />
+                    <NoteReader fromLiveStream={fromLiveStream} noteId={noteId} blocks={notes.blocks} date={date} verses={verses} entityMap={notes.entityMap} mode={mode} fontScale={fontScale} type='notes' openVerseCallback={handleOpenVerse} />
                 </Content>
                 <Content style={[style.content, { backgroundColor: mode === 'dark' ? 'black' : Theme.colors.grey6 }]} key='questions' >
-                    <NoteReader route={route} noteId={noteId} blocks={questions.blocks} date={date} verses={verses} entityMap={questions.entityMap} mode={mode} fontScale={fontScale} type='questions' openVerseCallback={handleOpenVerse} />
+                    <NoteReader fromLiveStream={fromLiveStream} noteId={noteId} blocks={questions.blocks} date={date} verses={verses} entityMap={questions.entityMap} mode={mode} fontScale={fontScale} type='questions' openVerseCallback={handleOpenVerse} />
                 </Content>
             </Swiper> : <ActivityIndicator />
         }


### PR DESCRIPTION
#### Implemented a yellow announcement bar on the homepage that only shows during a live event.
- Shows "We are live now!" for when an event is currently live, and "We will be going live soon!" Before the event starts.
- Clicking the yellow bar navigates the user to the livestream page.

![Screenshot_20201031-192656_Expo](https://user-images.githubusercontent.com/42515854/97792054-8c2e3f80-1baf-11eb-93d9-a49b77add960.jpg)

#### Livestream Page
- Shows Back arrow, Notes/Questions and page styling icon on the top bar
- Youtube video player. Shows Pre-roll before event video start time. Should automatically change to the live event once it goes live. Player stays on the top half of the screen regardless of scrolling
- Shows notes and questions content below video player.

![Screenshot_20201031-192647_Expo](https://user-images.githubusercontent.com/42515854/97792055-8df80300-1baf-11eb-93d9-31eacf5bc952.jpg)
