### PR TITLE
Event Card Improvements

### DIFF
--- a/components/home/EventCard/EventCard.tsx
+++ b/components/home/EventCard/EventCard.tsx
@@ -68,7 +68,7 @@ export default function EventCard({ event, handlePress }: EventCardInput): JSX.E
                 {event?.place?.name || event?.place?.location?.street ?
                     <Text style={style.locationContainer}>{event?.place?.name ? event.place.name.split(',')[0] : null}{event?.place?.location?.street ? `, ${event.place.location.street.split(',')[0]}` : null} </Text>
                     : null}
-                <Text style={style.dateTimeContainer}>{moment(event?.start_time).format("h:mm")}  {event?.end_time ? "- " + moment(event?.end_time).format("h:mm a") : ""}</Text>
+                <Text style={style.dateTimeContainer}>{moment(event?.start_time).format("h:mm")} {event?.end_time ? "- " + moment(event?.end_time).format("h:mm a") : ""}</Text>
             </View>
         </TouchableHighlight>
 

--- a/components/home/EventCard/EventCard.tsx
+++ b/components/home/EventCard/EventCard.tsx
@@ -68,9 +68,6 @@ export default function EventCard({ event, handlePress }: EventCardInput): JSX.E
             if (moment(event?.end_time).isSame(moment(event.start_time), 'day')) {
                 endTime = moment(event.end_time).format("h:mm a")
             }
-            else {
-                endTime = ""
-            }
         }
         if (endTime !== "")
             return startTime + " - " + endTime;
@@ -88,7 +85,7 @@ export default function EventCard({ event, handlePress }: EventCardInput): JSX.E
                 {event?.place?.name || event?.place?.location?.street ?
                     <Text style={style.locationContainer}>{event?.place?.name ? event.place.name.split(',')[0] : null}{event?.place?.location?.street ? `, ${event.place.location.street.split(',')[0]}` : null} </Text>
                     : null}
-                <Text style={style.dateTimeContainer}>{formatDate()}</Text>
+                {event?.start_time || event?.end_time ? <Text style={style.dateTimeContainer}>{formatDate()}</Text> : null}
             </View>
         </TouchableHighlight>
 

--- a/components/home/EventCard/EventCard.tsx
+++ b/components/home/EventCard/EventCard.tsx
@@ -3,9 +3,7 @@ import { Text, Thumbnail, View } from 'native-base';
 import moment from 'moment';
 import { EventQueryResult } from '../../../services/EventsService';
 import { Style, Theme } from '../../../Theme.style';
-import { StyleSheet } from 'react-native';
-import { TouchableHighlight } from 'react-native-gesture-handler';
-
+import { StyleSheet, TouchableHighlight } from 'react-native';
 
 const style = StyleSheet.create({
     container: {
@@ -23,23 +21,20 @@ const style = StyleSheet.create({
         }
     },
     titleButtonContainer: {
-        display: "flex",
         flexDirection: "row",
         marginBottom: 8,
         paddingLeft: 0,
         marginLeft: 0,
-        width: '100%',
-        justifyContent: "flex-start"
     },
     title: {
         ...Style.cardTitle, ...{
             paddingLeft: 0,
             paddingTop: 5,
-            flexGrow: 1,
+            width: "88%",
             lineHeight: 24,
         }
     },
-    icon: Style.icon,
+    icon: { ...Style.icon, position: "absolute", right: 0 },
     descriptionContainer: {
         ...Style.cardDescription, ...{
             marginBottom: 16,
@@ -56,6 +51,31 @@ type EventCardInput = {
 }
 
 export default function EventCard({ event, handlePress }: EventCardInput): JSX.Element {
+    const formatDate = () => {
+        let startTime = "", endTime = ""
+        if (event?.start_time) {
+            if (event?.end_time)
+                if (moment(event.end_time).isSame(moment(event.start_time), 'day'))
+                    startTime = moment(event.start_time).format("h:mm")
+                else {
+                    startTime = moment(event.start_time).format("h:mm a")
+                }
+            else {
+                startTime = moment(event.start_time).format("h:mm a")
+            }
+        }
+        if (event?.end_time) {
+            if (moment(event?.end_time).isSame(moment(event.start_time), 'day')) {
+                endTime = moment(event.end_time).format("h:mm a")
+            }
+            else {
+                endTime = ""
+            }
+        }
+        if (endTime !== "")
+            return startTime + " - " + endTime;
+        else return startTime
+    }
     return (
         <TouchableHighlight underlayColor={Theme.colors.grey5} onPress={handlePress}>
             <View style={style.container} >
@@ -68,7 +88,7 @@ export default function EventCard({ event, handlePress }: EventCardInput): JSX.E
                 {event?.place?.name || event?.place?.location?.street ?
                     <Text style={style.locationContainer}>{event?.place?.name ? event.place.name.split(',')[0] : null}{event?.place?.location?.street ? `, ${event.place.location.street.split(',')[0]}` : null} </Text>
                     : null}
-                <Text style={style.dateTimeContainer}>{moment(event?.start_time).format("h:mm")} {event?.end_time ? "- " + moment(event?.end_time).format("h:mm a") : ""}</Text>
+                <Text style={style.dateTimeContainer}>{formatDate()}</Text>
             </View>
         </TouchableHighlight>
 

--- a/screens/EventDetailsScreen.tsx
+++ b/screens/EventDetailsScreen.tsx
@@ -412,7 +412,7 @@ export default function EventDetailsScreen({
         <View
           style={
             eventItem?.cover?.source
-              ? [style.detailsContainer, { top: 30, zIndex: 2 }]
+              ? [style.detailsContainer, { marginTop: 40, zIndex: 2 }]
               : style.detailsContainer
           }
         >

--- a/screens/EventDetailsScreen.tsx
+++ b/screens/EventDetailsScreen.tsx
@@ -59,6 +59,7 @@ const style = StyleSheet.create({
     zIndex: 1,
     position: "absolute",
     alignSelf: "center",
+    marginTop: 80
   },
   dateBoxContainer: {
     display: "flex",
@@ -434,57 +435,57 @@ export default function EventDetailsScreen({
               })}
             </>
           ) : (
-            <>
-              <Text style={style.subtitle}>Date &amp; Time</Text>
-              <Text style={style.body}>
-                {moment(eventItem.start_time).format("ddd, MMM D, YYYY")},{" "}
-                {moment(eventItem.start_time).format("h:mm a")}{" "}
-                {eventItem.end_time
-                  ? "- " + moment(eventItem.end_time).format("h:mm a")
-                  : null}
-              </Text>
-            </>
-          )}
+              <>
+                <Text style={style.subtitle}>Date &amp; Time</Text>
+                <Text style={style.body}>
+                  {moment(eventItem.start_time).format("ddd, MMM D, YYYY")},{" "}
+                  {moment(eventItem.start_time).format("h:mm a")}{" "}
+                  {eventItem.end_time
+                    ? "- " + moment(eventItem.end_time).format("h:mm a")
+                    : null}
+                </Text>
+              </>
+            )}
           {(eventItem.event_times && eventItem.event_times.length !== 0) ||
-          (eventItem.start_time && eventItem.end_time) ? (
-            <IconButton
-              onPress={() => {
-                addEventToCalendar();
-              }}
-              style={style.actionButton}
-              icon={Theme.icons.white.calendarAdd}
-              label="Add to calendar"
-            ></IconButton>
-          ) : null}
+            (eventItem.start_time && eventItem.end_time) ? (
+              <IconButton
+                onPress={() => {
+                  addEventToCalendar();
+                }}
+                style={style.actionButton}
+                icon={Theme.icons.white.calendarAdd}
+                label="Add to calendar"
+              ></IconButton>
+            ) : null}
           {eventItem.event_times &&
-          eventItem.event_times?.length > 1 &&
-          Platform.OS === "android" ? (
-            <Picker
-              mode="dropdown"
-              enabled
-              prompt="Event Dates"
-              style={{ width: 500, height: 50, color: "white" }}
-              selectedValue={options}
-              onValueChange={(itemValue, itemIndex) => {
-                setOptions(itemValue as string);
-              }}
-            >
-              <Picker.Item label="Select a Date" value=""></Picker.Item>
-              {eventItem.event_times?.map((value: any, key: any) => {
-                if (value.start_time > moment().format())
-                  return (
-                    <Picker.Item
-                      key={key}
-                      label={`${moment(value.start_time).format(
-                        "MMM Do YYYY, h:mm a"
-                      )} - ${moment(value.end_time).format("h:mm a")}`}
-                      value={value}
-                    ></Picker.Item>
-                  );
-                else return null;
-              })}
-            </Picker>
-          ) : null}
+            eventItem.event_times?.length > 1 &&
+            Platform.OS === "android" ? (
+              <Picker
+                mode="dropdown"
+                enabled
+                prompt="Event Dates"
+                style={{ width: 500, height: 50, color: "white" }}
+                selectedValue={options}
+                onValueChange={(itemValue, itemIndex) => {
+                  setOptions(itemValue as string);
+                }}
+              >
+                <Picker.Item label="Select a Date" value=""></Picker.Item>
+                {eventItem.event_times?.map((value: any, key: any) => {
+                  if (value.start_time > moment().format())
+                    return (
+                      <Picker.Item
+                        key={key}
+                        label={`${moment(value.start_time).format(
+                          "MMM Do YYYY, h:mm a"
+                        )} - ${moment(value.end_time).format("h:mm a")}`}
+                        value={value}
+                      ></Picker.Item>
+                    );
+                  else return null;
+                })}
+              </Picker>
+            ) : null}
           {eventItem.place ? (
             <>
               <Text style={style.subtitle}>Location</Text>
@@ -504,16 +505,16 @@ export default function EventDetailsScreen({
           ) : null}
           <View>
             {eventItem?.event_times &&
-            eventItem?.event_times.length > 0 &&
-            eventItem?.event_times[0]?.ticket_uri ? (
-              <WhiteButton
-                style={{ height: 56, marginBottom: 20, marginTop: 20 }}
-                label="Register"
-                onPress={() => {
-                  Linking.openURL(eventItem.event_times[0].ticket_uri);
-                }}
-              ></WhiteButton>
-            ) : null}
+              eventItem?.event_times.length > 0 &&
+              eventItem?.event_times[0]?.ticket_uri ? (
+                <WhiteButton
+                  style={{ height: 56, marginBottom: 20, marginTop: 20 }}
+                  label="Register"
+                  onPress={() => {
+                    Linking.openURL(eventItem.event_times[0].ticket_uri);
+                  }}
+                ></WhiteButton>
+              ) : null}
 
             {parseDescription() !== "" ? (
               <WhiteButton

--- a/screens/EventDetailsScreen.tsx
+++ b/screens/EventDetailsScreen.tsx
@@ -59,7 +59,7 @@ const style = StyleSheet.create({
     zIndex: 1,
     position: "absolute",
     alignSelf: "center",
-    marginTop: 80
+    marginTop: 140
   },
   dateBoxContainer: {
     display: "flex",
@@ -390,7 +390,7 @@ export default function EventDetailsScreen({
           style={
             eventItem?.cover?.source
               ? style.dateBoxContainerWithPicture
-              : style.dateBoxContainer
+              : { ...style.dateBoxContainer, marginTop: -40 }
           }
         >
           <View
@@ -412,7 +412,7 @@ export default function EventDetailsScreen({
         <View
           style={
             eventItem?.cover?.source
-              ? [style.detailsContainer, { top: -40, zIndex: 2 }]
+              ? [style.detailsContainer, { top: 30, zIndex: 2 }]
               : style.detailsContainer
           }
         >


### PR DESCRIPTION
* [x] Removed extra white space on start_time - end_time
* [x] On multi-day events only the start_time will be shown

### Notes:


* event_times remains broken, meaning the add to calendar feature isn't showing for events with more than one instance.
* There is currently no easy way to distinguish between multi-day events and recurring events. 

partially resolves #179
resolves #180



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=613564960)
