### PR TITLE
Generate code coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,8 @@ jobs:
     - name: Build
       run: npm ci
     - name: Test
-      run: npm test
+      run: npm test -- --coverage
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
-        name: code-coverage-report
         path: coverage/lcov-report/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ web-report/
 .DS_Store
 
 version.js
+
+coverage

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "preset": "jest-expo",
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?react-native|@codler/react-native-keyboard-aware-scroll-view|react-clone-referenced-element|@react-native-community|expo(nent)?|@expo(nent)?/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|@sentry/.*)"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/assets/",
+      "Theme.style.ts"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Tests are failing because the workflow is trying to archive a coverage report that doesn't exist.



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=615447685)
