### PR TITLE
More Unit Tests, Fix Deprecation Warning For Clipboard API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14503,6 +14503,11 @@
         }
       }
     },
+    "expo-clipboard": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-1.0.1.tgz",
+      "integrity": "sha512-TQjMi9mAZr8jQOSl/XJLVwW6DTmjA3qAOUMk4BuxlMvJ1NqJbCITLEBwUcLW/rNewgmXLytoLzRpxadcxSfJAQ=="
+    },
     "expo-constants": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "react-native-webview": "11.0.0",
     "react-native-xml2js": "^1.0.3",
     "react-native-youtube-iframe": "^1.3.0",
-    "sentry-expo": "^3.0.4"
+    "sentry-expo": "^3.0.4",
+    "expo-clipboard": "~1.0.1"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -42,7 +42,10 @@ export default function SearchBar({
         />
 
         {searchText ? (
-          <TouchableOpacity onPress={() => handleTextChanged('')}>
+          <TouchableOpacity
+            onPress={() => handleTextChanged('')}
+            testID="close-search"
+          >
             <Thumbnail
               accessibilityLabel="Close Search"
               style={localStyle.searchIcon}

--- a/src/components/__tests__/AnnouncementBar.test.js
+++ b/src/components/__tests__/AnnouncementBar.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import AnnouncementBar from '../home/AnnouncementBar';
+
+const mockPush = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  return {
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+      push: mockPush,
+    }),
+  };
+});
+
+describe('announcement bar', () => {
+  test('children render', () => {
+    const { queryByText } = render(<AnnouncementBar message="test" />);
+    expect(queryByText('test')).toBeTruthy();
+  });
+
+  test('navigate', () => {
+    const { queryByText } = render(<AnnouncementBar message="test" />);
+    const touchable = queryByText('test');
+    fireEvent.press(touchable);
+    expect(mockPush).toBeCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('LiveStreamScreen');
+  });
+});

--- a/src/components/__tests__/InstagramFeed.test.js
+++ b/src/components/__tests__/InstagramFeed.test.js
@@ -342,6 +342,96 @@ const instaData = {
   },
 };
 
+const instaDataMissingFields = {
+  data: {
+    getInstagramByLocation: {
+      items: [
+        {
+          id: 'CJGmwEvlVri',
+          locationId: 'themeetinghouse',
+          thumbnails: [
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s150x150/132051851_741777823429247_843297535879666640_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=111&_nc_ohc=v6U7hx-q_L0AX-7AZQt&tp=1&oh=7e82ab10ea2ecf3c91e1c552cc6b906c&oe=600CCF56',
+              config_width: 150,
+              config_height: 150,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s240x240/132051851_741777823429247_843297535879666640_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=111&_nc_ohc=v6U7hx-q_L0AX-7AZQt&tp=1&oh=ce799575810eaf3a69ae2852b8183664&oe=600CAC20',
+              config_width: 240,
+              config_height: 240,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s320x320/132051851_741777823429247_843297535879666640_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=111&_nc_ohc=v6U7hx-q_L0AX-7AZQt&tp=1&oh=06da3fcbea192303937f803b1e9e8cdc&oe=600B0726',
+              config_width: 320,
+              config_height: 320,
+            },
+            {
+              src: null,
+              config_width: 480,
+              config_height: 480,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/sh0.08/e35/s640x640/132051851_741777823429247_843297535879666640_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=111&_nc_ohc=v6U7hx-q_L0AX-7AZQt&tp=1&oh=cb6ed1ea81bc138d807db49fd67602a9&oe=600DB173',
+              config_width: 640,
+              config_height: 640,
+            },
+          ],
+          altText: null,
+          timestamp: 1608646924,
+          createdAt: '2020-12-22T22:01:14.547Z',
+          updatedAt: '2020-12-23T14:01:19.194Z',
+        },
+        {
+          id: 'CJFLHM0lHp4',
+          locationId: 'themeetinghouse',
+          thumbnails: [
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s150x150/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=db4c419e98c9bacdb898c8edc08a5db1&oe=600BD5C6',
+              config_width: 150,
+              config_height: 150,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s240x240/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=c2649588c30f0fdb6b0835569b6d36b0&oe=600CBA44',
+              config_width: 240,
+              config_height: 240,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s320x320/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=89d30ec7b624c0c8cf91b255e8ee5e1a&oe=600D28BE',
+              config_width: 320,
+              config_height: 320,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s480x480/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=c1248d89dcba71de38ac3a7b18d0cfa3&oe=600D0BFB',
+              config_width: 480,
+              config_height: 480,
+            },
+            {
+              src:
+                'https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/sh0.08/e35/s640x640/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=77ccbe5589033d70ef2c25ec8e2be63e&oe=600AF9C1',
+              config_width: 640,
+              config_height: 640,
+            },
+          ],
+          altText: null,
+          timestamp: 1608598907,
+          createdAt: '2020-12-22T14:01:16.541Z',
+          updatedAt: '2020-12-23T14:01:19.409Z',
+        },
+      ],
+      nextToken:
+        'eyJ2ZXJzaW9uIjoyLCJ0b2tlbiI6IkFRSUNBSGg5OUIvN3BjWU41eE96NDZJMW5GeGM4WUNGeG1acmFOMUpqajZLWkFDQ25BRW1Cd25VOVdES3NTZ1VsbEpTbUFabEFBQURTekNDQTBjR0NTcUdTSWIzRFFFSEJxQ0NBemd3Z2dNMEFnRUFNSUlETFFZSktvWklodmNOQVFjQk1CNEdDV0NHU0FGbEF3UUJMakFSQkF3VEtLdzNTVFBCc3Jza2lRSUNBUkNBZ2dMK3V1czFWT1lZY2YwSUQvVmE5cWlib2Z3eU5vYjJzUU1Kb3haektQVGh3Y0lLblFHSzVrUlNhL29iQTBsRFhodHZYU0tCQlZwc3VWVDl1SDRwVi9qdGlsckdkRFUyY0FSclA1NThsR2U5RktzK3JOWkoyKzRadzZyVjNaYTE2RGFkeGJiNVNhb1luZXgxN0NxTjRremFranJ5bVYwV2pKTzFOL3BLeVUyOERlMG1XTXMyVW1LUGJwcnNWc0NIVlNkN0NzUXZSSnltcG9SdDlUMk11dXhsY2Q2MEJXUlpzekozRm9ReERRMWpENnZIdU9WY0Zsc1pMQTRRZFA4YnNrekE2ak92LzA4Y1M0clFiSXJVRHhzK3pGYTY0SFFValRQb0h2dVdGUTNqSFYwdXlTVHEra1dKK2RCMlIwMlExY3ZIdkFoYytFeWxqbG5yaDFPeXluZlFXcDZCRHZSU2trTmNqVkpmdzNWY0RGdDNNNnpyMTY2K28xaEtaRDd4VGpqNk1RYU4wRWlncy9pSjNaeTFGclRmbXVJV21wUHhtQll3NTVnQWJFL1ZZVDRJbVJpZ0dnWkZ0cnpPay9nQk14TE8yWGllb01Jb0swdE9RZWZsNjFpeHk5QlZWOFBpa2V5RGxkaklNeThBYTdSZjZQaVFmckhwRmJSb01GN1hqR0tPZFFidWk5T1h1ZGZ0WFpHOHRqOGMrd0wzd1lmYUxVTDlsQjdmU3BCNmZKVlZ5ZzFJc3NwOVd1ME1EUlRrdlZhYVo3SjlRTjVWaVJiTXVOMDFjYXk1Nkg2NU9rWnMrNC92Unl5MkRJOGtmcU5NdWUxdkl2Z0MvaHVmKzJkakJyaFMxZXo2YW5MRGxmbjk2SzYxTFJBWEwvSGkvY3VHM2h5SE5KQy9CTW01Y01FbnRkd0NaSEIwWm5VbjhSUkpkZHh4S0ZXY1ZzT0dna1FMa1hMVytMTWR5YS90aEErUFkwSEJtbFVyL2UyVWJjZElkWHc4WUkwSm1uK2RxM25wTDhlS1dyTWcybnJxR3JKYTFuYzE5UnBuVnd5VEtxK1EzS3BrWjJXVDZ3a0VZa3FMWTl5NnM3T2R3VU1qeVJCYnRyS1ZhK21jVDdCUFFmbSsycWtXcHNxbGlJTk9pWW5oTllPc1RrZHpXK2FCUGRhWm4xbnZ1RGp1bzlaRjAxNlJXblgzZjlWUnRKSGdzWkdyVEtKRFJBbjREbFNkbXRremlZTzVtdFlkdFhzVUcrOUFvNjUwemY5N2Nzek02aU8xeUo2RmZ0MytOc1RxNVNTRzFyQWVLRmpPOEFWdTBSU2VhT2F1SzVocnVlMkNyNEZMMlNUYnpKMllROHZVa08xV1lBPT0ifQ==',
+    },
+  },
+};
+
 const dataLength = instaData.data.getInstagramByLocation.items.length;
 
 describe('Instagram grid', () => {
@@ -401,5 +491,37 @@ describe('Instagram grid', () => {
 
     // n-2 images render
     expect(queryAllByRole('imagebutton').length).toEqual(dataLength - 2);
+  });
+
+  test('Missing fields in data', () => {
+    const { toJSON, queryAllByRole } = render(
+      <InstagramFeed
+        images={instaDataMissingFields.data.getInstagramByLocation.items}
+      />
+    );
+
+    expect(
+      queryAllByRole('imagebutton')[0].props.children.props.accessibilityLabel
+    ).toBe('tap to view on Instagram');
+
+    expect(
+      queryAllByRole('imagebutton')[0].props.children.props.source
+    ).toStrictEqual({
+      uri: '',
+    });
+
+    expect(
+      queryAllByRole('imagebutton')[1].props.children.props.accessibilityLabel
+    ).toBe('tap to view on Instagram');
+
+    expect(
+      queryAllByRole('imagebutton')[1].props.children.props.source
+    ).toStrictEqual({
+      uri:
+        instaDataMissingFields.data.getInstagramByLocation.items[1]
+          .thumbnails[3].src,
+    });
+
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/src/components/__tests__/InstagramFeed.test.js
+++ b/src/components/__tests__/InstagramFeed.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react-native';
-import { Linking } from 'react-native';
+import * as Linking from 'expo-linking';
 import InstagramFeed from '../home/InstagramFeed';
 
 const instaData = {

--- a/src/components/__tests__/Modals.test.js
+++ b/src/components/__tests__/Modals.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { Share, Platform } from 'react-native';
+import Clipboard from 'expo-clipboard';
+import * as Linking from 'expo-linking';
+import { render, fireEvent } from '@testing-library/react-native';
+import NeedsSignUpModal from '../modals/NeedsSignUpModal';
+import ShareModal from '../modals/Share';
+
+const mockPush = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  return {
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+      push: mockPush,
+      goBack: mockGoBack,
+    }),
+  };
+});
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockGoBack.mockReset();
+});
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({
+    insets: { top: 0, bottom: 0, left: 0, right: 0 },
+  }),
+}));
+
+describe('share modal', () => {
+  const cb = jest.fn();
+
+  const message = 'this is a message';
+  const link = 'https://themeetinghouse.com';
+
+  test('clipboard', () => {
+    Clipboard.setString = jest.fn();
+
+    const { queryByText } = render(
+      <ShareModal link={link} message={message} closeCallback={cb} />
+    );
+
+    expect(queryByText('Copy Link')).toBeTruthy();
+
+    const copyButton = queryByText('Copy Link');
+
+    fireEvent.press(copyButton);
+
+    expect(queryByText('Copied')).toBeTruthy();
+    expect(Clipboard.setString).toHaveBeenCalledWith(link);
+  });
+
+  test('twitter', () => {
+    Linking.openURL = jest.fn();
+
+    const { queryByTestId } = render(
+      <ShareModal link={link} message={message} closeCallback={cb} />
+    );
+
+    const btn = queryByTestId('twitter');
+
+    fireEvent.press(btn);
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      `https://twitter.com/intent/tweet?text=${message}&url=${link}&via=themeetinghouse`
+    );
+  });
+
+  test('share, ios', () => {
+    Share.share = jest.fn();
+    Platform.OS = 'ios';
+
+    const { queryByTestId } = render(
+      <ShareModal link={link} message={message} closeCallback={cb} />
+    );
+
+    const btn = queryByTestId('share');
+
+    fireEvent.press(btn);
+
+    expect(Share.share).toHaveBeenCalledWith({
+      url: link,
+      message,
+    });
+  });
+
+  test('share, android', () => {
+    Share.share = jest.fn();
+    Platform.OS = 'android';
+
+    const { queryByTestId } = render(
+      <ShareModal link={link} message={message} closeCallback={cb} />
+    );
+
+    const btn = queryByTestId('share');
+
+    fireEvent.press(btn);
+
+    expect(Share.share).toHaveBeenCalledWith({ message: link, title: message });
+  });
+});
+
+describe('needs sign up to use notes modal', () => {
+  test('initState true, create account', () => {
+    const { getByTestId, queryByText } = render(<NeedsSignUpModal initState />);
+
+    expect(getByTestId('modal').props.visible).toBeTruthy();
+
+    const createAccount = queryByText('Create an account');
+
+    fireEvent.press(createAccount);
+    expect(mockPush).toHaveBeenCalledWith('Auth', { screen: 'SignUpScreen' });
+
+    expect(getByTestId('modal').props.visible).toBeFalsy();
+  });
+
+  test('initState true, go back', () => {
+    const { getByTestId, queryByText } = render(<NeedsSignUpModal initState />);
+
+    expect(getByTestId('modal').props.visible).toBeTruthy();
+
+    const goBack = queryByText('Go back');
+
+    fireEvent.press(goBack);
+    expect(mockGoBack).toHaveBeenCalled();
+
+    expect(getByTestId('modal').props.visible).toBeFalsy();
+  });
+
+  test('initState false, control state from parent', () => {
+    let state = false;
+
+    const { getByTestId, rerender } = render(
+      <NeedsSignUpModal initState={state} />
+    );
+
+    expect(getByTestId('modal').props.visible).toBeFalsy();
+
+    state = true;
+
+    rerender(<NeedsSignUpModal initState={state} />);
+
+    expect(getByTestId('modal').props.visible).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/SearchBar.test.js
+++ b/src/components/__tests__/SearchBar.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import SearchBar from '../SearchBar';
+
+const mockHandler = jest.fn();
+
+describe('search bar', () => {
+  test('handleTextChanged, cancel button', () => {
+    const { queryByPlaceholderText, queryByTestId } = render(
+      <SearchBar
+        style={{}}
+        searchText="test"
+        placeholderLabel="placeholder"
+        handleTextChanged={(e) => mockHandler(e)}
+      />
+    );
+
+    expect(queryByPlaceholderText('placeholder')).toBeTruthy();
+
+    const input = queryByPlaceholderText('placeholder');
+
+    fireEvent.changeText(input, 'jesus is a');
+    fireEvent.changeText(input, 'jesus is a cool dude');
+
+    expect(mockHandler).toHaveBeenCalledTimes(2);
+    expect(mockHandler).toHaveBeenCalledWith('jesus is a');
+    expect(mockHandler).toHaveBeenLastCalledWith('jesus is a cool dude');
+
+    expect(queryByTestId('close-search')).toBeTruthy();
+    const button = queryByTestId('close-search');
+
+    fireEvent.press(button);
+    expect(mockHandler).toHaveBeenLastCalledWith('');
+  });
+
+  test('cancel button not rendered if no searchText', () => {
+    const { queryByTestId } = render(
+      <SearchBar
+        style={{}}
+        searchText=""
+        placeholderLabel="placeholder"
+        handleTextChanged={(e) => mockHandler(e)}
+      />
+    );
+
+    expect(queryByTestId('close-search')).toBeFalsy();
+  });
+});

--- a/src/components/__tests__/Staff.test.js
+++ b/src/components/__tests__/Staff.test.js
@@ -1,0 +1,282 @@
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import * as Linking from 'expo-linking';
+import StaffItem from '../staff/StaffItem';
+import TeacherItem from '../staff/TeacherItem';
+
+const staffIsTeacher = {
+  FirstName: 'Luke',
+  LastName: 'Skywalker',
+  Email: 'luke.skywalker@themeetinghouse.com',
+  Position: 'Jedi',
+  Phone: '905-509-1234',
+  sites: [],
+  Location: null,
+  Coordinator: null,
+  Teacher: true,
+  uri: 'some-uri.png',
+};
+
+const staffIsNotTeacher = {
+  FirstName: 'Luke',
+  LastName: 'Skywalker',
+  Email: 'luke.skywalker@themeetinghouse.com',
+  Position: 'Jedi',
+  Phone: '905-509-1234',
+  sites: [],
+  Location: null,
+  Coordinator: null,
+  Teacher: false,
+  uri: 'some-uri.png',
+};
+
+const staffMissingData = {
+  FirstName: 'Luke',
+  LastName: '',
+  Email: '',
+  Position: '',
+  Phone: '',
+  sites: [],
+  Location: null,
+  Coordinator: null,
+  Teacher: false,
+  uri: '',
+};
+
+const teacher = {
+  id: '123456789',
+  name: 'Biggs Darklighter',
+  Phone: '905-509-1313',
+  Email: 'biggs.darklighter@themeetinghouse.com',
+  image: 'picture.jpg',
+};
+
+const teacherMissingData = {
+  id: '123456789',
+  name: '',
+  Phone: '',
+  Email: '',
+  image: '',
+};
+
+const mockPush = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  return {
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({
+      push: mockPush,
+    }),
+  };
+});
+
+beforeEach(() => {
+  mockPush.mockReset();
+});
+
+describe('staff item', () => {
+  test('ios, fallback image', () => {
+    Platform.OS = 'ios';
+
+    const { queryByTestId } = render(<StaffItem staff={staffIsTeacher} />);
+
+    expect(queryByTestId('ios-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('ios-image').props.onError();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeTruthy();
+  });
+
+  test('ios, image loads', () => {
+    Platform.OS = 'ios';
+
+    const { queryByTestId } = render(<StaffItem staff={staffIsTeacher} />);
+
+    expect(queryByTestId('ios-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('ios-image').props.onLoadEnd();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeFalsy();
+  });
+
+  test('android, fallback image', () => {
+    Platform.OS = 'android';
+
+    const { queryByTestId } = render(<StaffItem staff={staffIsTeacher} />);
+
+    expect(queryByTestId('android-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('android-image').props.onError();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeTruthy();
+  });
+
+  test('android, image loads', () => {
+    Platform.OS = 'android';
+
+    const { queryByTestId } = render(<StaffItem staff={staffIsTeacher} />);
+
+    expect(queryByTestId('android-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('android-image').props.onLoadEnd();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeFalsy();
+  });
+
+  test('teacher = true, navigation', () => {
+    const { queryByText } = render(<StaffItem staff={staffIsTeacher} />);
+
+    expect(queryByText('View Teaching')).toBeTruthy();
+
+    const button = queryByText('View Teaching');
+
+    fireEvent.press(button);
+
+    expect(mockPush).toHaveBeenCalledWith('TeacherProfile', {
+      staff: staffIsTeacher,
+    });
+  });
+
+  test('teacher = false', () => {
+    const { queryByText } = render(<StaffItem staff={staffIsNotTeacher} />);
+
+    expect(queryByText('View Teaching')).toBeFalsy();
+  });
+
+  test('email, phone', () => {
+    Linking.openURL = jest.fn();
+
+    const { queryByTestId } = render(<StaffItem staff={staffIsTeacher} />);
+
+    const tel = queryByTestId('tel-btn');
+    const email = queryByTestId('email-btn');
+
+    fireEvent.press(tel);
+    expect(Linking.openURL).toHaveBeenCalledWith(`tel:${staffIsTeacher.Phone}`);
+
+    fireEvent.press(email);
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      `mailto:${staffIsTeacher.Email}`
+    );
+  });
+
+  test('missing data', () => {
+    const { queryByTestId, queryByText } = render(
+      <StaffItem staff={staffMissingData} />
+    );
+
+    expect(queryByText('View Teaching')).toBeFalsy();
+    expect(queryByTestId('tel-btn')).toBeFalsy();
+    expect(queryByTestId('email-btn')).toBeFalsy();
+    expect(queryByTestId('staff-name')).toBeFalsy();
+    expect(queryByTestId('staff-position')).toBeFalsy();
+  });
+});
+
+describe('teacher item', () => {
+  test('ios, fallback image', () => {
+    Platform.OS = 'ios';
+
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    expect(queryByTestId('ios-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('ios-image').props.onError();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeTruthy();
+  });
+
+  test('ios, image loads', () => {
+    Platform.OS = 'ios';
+
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    expect(queryByTestId('ios-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('ios-image').props.onLoadEnd();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeFalsy();
+  });
+
+  test('android, fallback image', () => {
+    Platform.OS = 'android';
+
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    expect(queryByTestId('android-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('android-image').props.onError();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeTruthy();
+  });
+
+  test('android, image loads', () => {
+    Platform.OS = 'android';
+
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    expect(queryByTestId('android-image')).toBeTruthy();
+
+    act(() => {
+      queryByTestId('android-image').props.onLoadEnd();
+    });
+
+    expect(queryByTestId('fallback-image')).toBeFalsy();
+  });
+
+  test('email, phone', () => {
+    Linking.openURL = jest.fn();
+
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    const tel = queryByTestId('tel-btn');
+    const email = queryByTestId('email-btn');
+
+    fireEvent.press(tel);
+    expect(Linking.openURL).toHaveBeenCalledWith(`tel:${teacher.Phone}`);
+
+    fireEvent.press(email);
+    expect(Linking.openURL).toHaveBeenCalledWith(`mailto:${teacher.Email}`);
+  });
+
+  test('missing data', () => {
+    const { queryByTestId } = render(
+      <TeacherItem teacher={teacherMissingData} />
+    );
+
+    expect(queryByTestId('tel-btn')).toBeFalsy();
+    expect(queryByTestId('email-btn')).toBeFalsy();
+    expect(queryByTestId('teacher-name')).toBeFalsy();
+  });
+
+  test('navigation', () => {
+    const { queryByTestId } = render(<TeacherItem teacher={teacher} />);
+
+    const touchable = queryByTestId('go-to-teacher');
+    fireEvent.press(touchable);
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith('Main', {
+      screen: 'More',
+      params: {
+        screen: 'TeacherProfile',
+        params: { staff: { idFromTeaching: teacher.id } },
+      },
+    });
+  });
+});

--- a/src/components/__tests__/__snapshots__/InstagramFeed.test.js.snap
+++ b/src/components/__tests__/__snapshots__/InstagramFeed.test.js.snap
@@ -316,3 +316,92 @@ exports[`Instagram grid Each image should render, check snapshot 1`] = `
   </RNGestureHandlerButton>
 </View>
 `;
+
+exports[`Instagram grid Missing fields in data 1`] = `
+<View
+  style={
+    Object {
+      "display": "flex",
+      "flexDirection": "row",
+      "flexWrap": "wrap",
+    }
+  }
+>
+  <RNGestureHandlerButton
+    collapsable={false}
+    onGestureEvent={[Function]}
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
+    onHandlerStateChange={[Function]}
+    rippleColor={0}
+  >
+    <View
+      accessibilityRole="imagebutton"
+      accessible={true}
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "height": 375,
+          "justifyContent": "center",
+          "width": 375,
+        }
+      }
+    >
+      <Image
+        accessibilityLabel="tap to view on Instagram"
+        onError={[Function]}
+        source={
+          Object {
+            "uri": "",
+          }
+        }
+        style={
+          Object {
+            "height": 330,
+            "width": 330,
+          }
+        }
+      />
+    </View>
+  </RNGestureHandlerButton>
+  <RNGestureHandlerButton
+    collapsable={false}
+    onGestureEvent={[Function]}
+    onGestureHandlerEvent={[Function]}
+    onGestureHandlerStateChange={[Function]}
+    onHandlerStateChange={[Function]}
+    rippleColor={0}
+  >
+    <View
+      accessibilityRole="imagebutton"
+      accessible={true}
+      style={
+        Object {
+          "alignItems": "center",
+          "display": "flex",
+          "height": 375,
+          "justifyContent": "center",
+          "width": 375,
+        }
+      }
+    >
+      <Image
+        accessibilityLabel="tap to view on Instagram"
+        onError={[Function]}
+        source={
+          Object {
+            "uri": "https://scontent-yyz1-1.cdninstagram.com/v/t51.2885-15/e35/s480x480/131416756_861339737952168_3081219852457107335_n.jpg?_nc_ht=scontent-yyz1-1.cdninstagram.com&_nc_cat=100&_nc_ohc=qbisne7qvrgAX8y36aV&tp=1&oh=c1248d89dcba71de38ac3a7b18d0cfa3&oe=600D0BFB",
+          }
+        }
+        style={
+          Object {
+            "height": 330,
+            "width": 330,
+          }
+        }
+      />
+    </View>
+  </RNGestureHandlerButton>
+</View>
+`;

--- a/src/components/home/InstagramFeed.tsx
+++ b/src/components/home/InstagramFeed.tsx
@@ -27,8 +27,7 @@ function InstagramImage({
 }): JSX.Element | null {
   const [validImage, setValidImage] = useState(true);
 
-  if (!validImage) return null;
-  if (image?.thumbnails)
+  if (validImage && image?.thumbnails) {
     return (
       <TouchableHighlight
         accessibilityRole="imagebutton"
@@ -44,6 +43,8 @@ function InstagramImage({
         />
       </TouchableHighlight>
     );
+  }
+
   return null;
 }
 

--- a/src/components/modals/NeedsSignUpModal.tsx
+++ b/src/components/modals/NeedsSignUpModal.tsx
@@ -16,7 +16,12 @@ export default function NeedsSignUpModal({ initState }: Params): JSX.Element {
   const [visible, setVisible] = useState(true);
 
   return (
-    <Modal animationType="none" visible={initState && visible} transparent>
+    <Modal
+      testID="modal"
+      animationType="none"
+      visible={initState && visible}
+      transparent
+    >
       <View style={{ flex: 1, justifyContent: 'center' }}>
         <View
           style={{

--- a/src/components/modals/Share.tsx
+++ b/src/components/modals/Share.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Clipboard, Share, Platform, Animated } from 'react-native';
+import { Share, Platform, Animated } from 'react-native';
+import Clipboard from 'expo-clipboard';
 import { Button, View, Text, Thumbnail } from 'native-base';
 import * as Linking from 'expo-linking';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -77,6 +78,7 @@ export default function ShareModal({
       onHandlerStateChange={(e) => handleGestureEnd(e)}
     >
       <Animated.View
+        testID="test"
         style={{
           position: 'absolute',
           width: '100%',
@@ -138,6 +140,7 @@ export default function ShareModal({
         </Button>
         <View style={{ display: 'flex', flexDirection: 'row', marginTop: 16 }}>
           <Button
+            testID="twitter"
             style={{
               flexGrow: 1,
               height: 56,
@@ -158,6 +161,7 @@ export default function ShareModal({
             />
           </Button>
           <Button
+            testID="share"
             style={{
               flexGrow: 1,
               height: 56,

--- a/src/components/modals/Share.tsx
+++ b/src/components/modals/Share.tsx
@@ -78,7 +78,6 @@ export default function ShareModal({
       onHandlerStateChange={(e) => handleGestureEnd(e)}
     >
       <Animated.View
-        testID="test"
         style={{
           position: 'absolute',
           width: '100%',

--- a/src/components/staff/StaffItem.tsx
+++ b/src/components/staff/StaffItem.tsx
@@ -109,6 +109,7 @@ function StaffItem({ staff }: Props): JSX.Element {
       if (Platform.OS === 'android') {
         return (
           <CachedImage
+            testID="android-image"
             onLoadEnd={() => setIsLoading(false)}
             style={style.picture}
             onError={() => {
@@ -121,6 +122,7 @@ function StaffItem({ staff }: Props): JSX.Element {
       }
       return (
         <Image
+          testID="ios-image"
           onLoadEnd={() => setIsLoading(false)}
           style={style.picture}
           onError={() => {
@@ -134,7 +136,11 @@ function StaffItem({ staff }: Props): JSX.Element {
 
     return (
       <View style={style.fallbackPictureContainer}>
-        <Image style={style.fallBackPicture} source={Theme.icons.white.user} />
+        <Image
+          style={style.fallBackPicture}
+          source={Theme.icons.white.user}
+          testID="fallback-image"
+        />
       </View>
     );
   };
@@ -152,12 +158,14 @@ function StaffItem({ staff }: Props): JSX.Element {
       </View>
       <View style={{ flexDirection: 'column' }}>
         {staff.FirstName && staff.LastName ? (
-          <Text style={style.Name}>
+          <Text testID="staff-name" style={style.Name}>
             {staff.FirstName} {staff.LastName}
           </Text>
         ) : null}
         {staff.Position ? (
-          <Text style={style.Position}>{staff.Position}</Text>
+          <Text testID="staff-position" style={style.Position}>
+            {staff.Position}
+          </Text>
         ) : null}
         {staff.Teacher ? (
           <TouchableOpacity
@@ -175,6 +183,7 @@ function StaffItem({ staff }: Props): JSX.Element {
         <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
           {staff.Phone ? (
             <TouchableOpacity
+              testID="tel-btn"
               onPress={() => Linking.openURL(`tel:${staff.Phone}`)}
               style={style.iconContainer}
             >
@@ -187,6 +196,7 @@ function StaffItem({ staff }: Props): JSX.Element {
           ) : null}
           {staff.Email ? (
             <TouchableOpacity
+              testID="email-btn"
               onPress={() => Linking.openURL(`mailto:${staff.Email}`)}
               style={style.iconContainer}
             >

--- a/src/components/staff/TeacherItem.tsx
+++ b/src/components/staff/TeacherItem.tsx
@@ -104,6 +104,7 @@ function TeacherItem({ teacher }: Props): JSX.Element {
       if (Platform.OS === 'android') {
         return (
           <CachedImage
+            testID="android-image"
             onLoadEnd={() => setIsLoading(false)}
             style={style.picture}
             onError={() => {
@@ -116,6 +117,7 @@ function TeacherItem({ teacher }: Props): JSX.Element {
       }
       return (
         <Image
+          testID="ios-image"
           onLoadEnd={() => setIsLoading(false)}
           style={style.picture}
           onError={() => {
@@ -128,13 +130,18 @@ function TeacherItem({ teacher }: Props): JSX.Element {
     }
     return (
       <View style={style.fallbackPictureContainer}>
-        <Image style={style.fallBackPicture} source={Theme.icons.white.user} />
+        <Image
+          style={style.fallBackPicture}
+          source={Theme.icons.white.user}
+          testID="fallback-image"
+        />
       </View>
     );
   };
 
   return (
     <TouchableOpacity
+      testID="go-to-teacher"
       onPress={() => {
         navigation.push('Main', {
           screen: 'More',
@@ -156,7 +163,11 @@ function TeacherItem({ teacher }: Props): JSX.Element {
           {renderTeacherImage()}
         </View>
         <View style={{ flexDirection: 'column' }}>
-          {teacher.name ? <Text style={style.Name}>{teacher.name}</Text> : null}
+          {teacher.name ? (
+            <Text style={style.Name} testID="teacher-name">
+              {teacher.name}
+            </Text>
+          ) : null}
 
           <Text style={style.Position}>{teacher.Position ?? 'Friend'}</Text>
           <Text style={style.footerText}>View Teaching</Text>
@@ -165,6 +176,7 @@ function TeacherItem({ teacher }: Props): JSX.Element {
           <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
             {teacher.Phone ? (
               <TouchableOpacity
+                testID="tel-btn"
                 onPress={() => Linking.openURL(`tel:${teacher.Phone}`)}
                 style={style.iconContainer}
               >
@@ -177,6 +189,7 @@ function TeacherItem({ teacher }: Props): JSX.Element {
             ) : null}
             {teacher.Email ? (
               <TouchableOpacity
+                testID="email-btn"
                 onPress={() => Linking.openURL(`mailto:${teacher.Email}`)}
                 style={style.iconContainer}
               >


### PR DESCRIPTION
Increases code coverage on the Instagram test suite.

New test suites for:


* Search Bar
* Announcement Bar
* Staff and Teacher Items
* Modals

Also, takes care of a [deprecation warning](https://reactnative.dev/docs/clipboard) with the React Native Clipboard API. Migrates to [expo-clipboard](https://docs.expo.io/versions/v40.0.0/sdk/clipboard/).



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=621653900)
