### PR TITLE
Sign-up/sign-in improvements, componentize password requirements

### DIFF
--- a/src/components/auth/PasswordRequirements.tsx
+++ b/src/components/auth/PasswordRequirements.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { View, Text, StyleProp, ViewStyle } from 'react-native';
+import { Entypo } from '@expo/vector-icons';
+import { Theme } from '../../Theme.style';
+
+interface PasswordIconProps {
+  meetsRequirement: boolean;
+  requirement: string;
+}
+
+function PasswordRequirement({
+  meetsRequirement,
+  requirement,
+}: PasswordIconProps) {
+  return (
+    <View
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 4,
+        backgroundColor: Theme.colors.grey1,
+        paddingRight: 10,
+        paddingLeft: 6,
+        borderRadius: 40,
+        marginRight: 8,
+        paddingVertical: 4,
+      }}
+    >
+      {meetsRequirement ? (
+        <Entypo name="check" size={14} color={Theme.colors.green} />
+      ) : (
+        <Entypo name="cross" size={14} color={Theme.colors.red} />
+      )}
+      <Text
+        style={{
+          color: 'white',
+          fontFamily: Theme.fonts.fontFamilyRegular,
+          fontSize: 14,
+          marginLeft: 4,
+        }}
+      >
+        {requirement}
+      </Text>
+    </View>
+  );
+}
+
+interface Props {
+  password: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+export default function PasswordRequirements({
+  password,
+  style,
+}: Props): JSX.Element {
+  return (
+    <View
+      style={[
+        style,
+        {
+          display: 'flex',
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          marginTop: 12,
+        },
+      ]}
+    >
+      <Text
+        style={{
+          color: 'white',
+          fontFamily: Theme.fonts.fontFamilyBold,
+          fontSize: 14,
+          marginRight: 8,
+        }}
+      >
+        Password must contain at least:
+      </Text>
+      <PasswordRequirement
+        meetsRequirement={password.length >= 8}
+        requirement="8 characters"
+      />
+      <PasswordRequirement
+        meetsRequirement={/(?=.*[A-Z])/.test(password)}
+        requirement="upper &amp; lowercase letters"
+      />
+      <PasswordRequirement
+        meetsRequirement={/(?=.*[0-9])/.test(password)}
+        requirement="1 number"
+      />
+      <PasswordRequirement
+        // eslint-disable-next-line no-useless-escape
+        meetsRequirement={/(?=.*[\=\+\$\*\.\,\?\"\!\@\#\%\&\'\:\;\[\]\{\}\(\)\/\\\>\<\|\_\~\`\^\-])/.test(
+          password
+        )}
+        requirement="1 special character (e.g. @ ! $ ^ ?)"
+      />
+    </View>
+  );
+}

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -7,7 +7,7 @@ import LocationSelectionScreen from '../screens/auth/LocationSelectionScreen';
 import SignUp from '../screens/auth/SignUp';
 
 export type AuthStackParamList = {
-  LoginScreen: undefined | { newUser: boolean };
+  LoginScreen: undefined | { newUser?: boolean; email?: string };
   SignUpScreen: undefined | { locationName: string; locationId: string };
   LocationSelectionScreen: undefined;
   ForgotPasswordScreen: undefined;

--- a/src/screens/auth/ConfirmSignUp.tsx
+++ b/src/screens/auth/ConfirmSignUp.tsx
@@ -84,11 +84,10 @@ export default function ConfirmSignUp({ navigation }: Params): JSX.Element {
   }, [email]);
 
   function toLogin(isNewUser: boolean): void {
-    setUser('');
     setCode('');
     setError('');
     setNeedsNewCode(false);
-    navigation.navigate('LoginScreen', { newUser: isNewUser });
+    navigation.navigate('LoginScreen', { newUser: isNewUser, email: user });
   }
 
   const confirm = async () => {

--- a/src/screens/auth/ConfirmSignUp.tsx
+++ b/src/screens/auth/ConfirmSignUp.tsx
@@ -5,8 +5,6 @@ import {
   View,
   TextInput,
   Text,
-  NativeSyntheticEvent,
-  TextInputKeyPressEventData,
   TouchableWithoutFeedback,
   Keyboard,
   SafeAreaView,
@@ -103,12 +101,6 @@ export default function ConfirmSignUp({ navigation }: Params): JSX.Element {
     }
     setSending(false);
   };
-
-  function handleEnter(
-    keyEvent: NativeSyntheticEvent<TextInputKeyPressEventData>
-  ): void {
-    if (keyEvent.nativeEvent.key === 'Enter') confirm();
-  }
 
   const getNewCode = async () => {
     setSending(true);
@@ -208,7 +200,7 @@ export default function ConfirmSignUp({ navigation }: Params): JSX.Element {
             <Text style={style.title}>One-Time Security Code</Text>
             <TextInput
               accessibilityLabel="One Time Code"
-              onKeyPress={(e) => handleEnter(e)}
+              onSubmitEditing={confirm}
               keyboardAppearance="dark"
               textContentType="oneTimeCode"
               keyboardType="number-pad"

--- a/src/screens/auth/ForgotPassword.tsx
+++ b/src/screens/auth/ForgotPassword.tsx
@@ -5,8 +5,6 @@ import {
   View,
   TextInput,
   Text,
-  NativeSyntheticEvent,
-  TextInputKeyPressEventData,
   TouchableWithoutFeedback,
   SafeAreaView,
   Keyboard,
@@ -111,13 +109,6 @@ export default function ForgotPassword({ navigation }: Params): JSX.Element {
     });
   }
 
-  function handleEnter(
-    keyEvent: NativeSyntheticEvent<TextInputKeyPressEventData>,
-    cb: () => void
-  ): void {
-    if (keyEvent.nativeEvent.key === 'Enter') cb();
-  }
-
   const sendCode = async () => {
     setSending(true);
     try {
@@ -175,7 +166,7 @@ export default function ForgotPassword({ navigation }: Params): JSX.Element {
               <Text style={style.title}>Email</Text>
               <TextInput
                 accessibilityLabel="Email Address"
-                onKeyPress={(e) => handleEnter(e, sendCode)}
+                onSubmitEditing={sendCode}
                 keyboardAppearance="dark"
                 autoCompleteType="email"
                 textContentType="emailAddress"
@@ -248,7 +239,7 @@ export default function ForgotPassword({ navigation }: Params): JSX.Element {
                 textContentType="newPassword"
                 passwordRules="required: lower; required: upper; required: digit; required: special; minlength: 8;"
                 keyboardAppearance="dark"
-                onKeyPress={(e) => handleEnter(e, reset)}
+                onSubmitEditing={reset}
                 value={pass}
                 onChange={(e) => setPass(e.nativeEvent.text)}
                 secureTextEntry

--- a/src/screens/auth/ForgotPassword.tsx
+++ b/src/screens/auth/ForgotPassword.tsx
@@ -20,6 +20,7 @@ import UserContext from '../../contexts/UserContext';
 import { AuthStackParamList } from '../../navigation/AuthNavigator';
 import { MainStackParamList } from '../../navigation/AppNavigator';
 import NoMedia from '../../components/NoMedia';
+import PasswordRequirements from '../../components/auth/PasswordRequirements';
 
 const style = StyleSheet.create({
   title: {
@@ -90,12 +91,11 @@ export default function ForgotPassword({ navigation }: Params): JSX.Element {
   }
 
   function toLogin(): void {
-    setUser('');
     setPass('');
     setCode('');
     setError('');
     setCodeSent(false);
-    navigation.push('LoginScreen');
+    navigation.push('LoginScreen', { email: user });
   }
 
   function toHome(): void {
@@ -245,6 +245,7 @@ export default function ForgotPassword({ navigation }: Params): JSX.Element {
                 secureTextEntry
                 style={style.input}
               />
+              <PasswordRequirements password={pass} />
               <View style={{ marginTop: 12 }}>
                 <Text
                   style={{

--- a/src/screens/auth/Login.tsx
+++ b/src/screens/auth/Login.tsx
@@ -4,8 +4,6 @@ import {
   View,
   Text,
   TextInput,
-  NativeSyntheticEvent,
-  TextInputKeyPressEventData,
   TouchableOpacity,
   Dimensions,
   StatusBar,
@@ -133,13 +131,6 @@ export default function Login({ navigation }: Params): JSX.Element {
     });
   }
 
-  function handleEnter(
-    keyEvent: NativeSyntheticEvent<TextInputKeyPressEventData>,
-    cb: () => void
-  ): void {
-    if (keyEvent.nativeEvent.key === 'Enter') cb();
-  }
-
   const mapObj = (f: any) => (obj: any) =>
     Object.keys(obj).reduce((acc, key) => ({ ...acc, [key]: f(obj[key]) }), {});
   const toArrayOfStrings = (value: any) => [`${value}`];
@@ -257,7 +248,7 @@ export default function Login({ navigation }: Params): JSX.Element {
             keyboardAppearance="dark"
             autoCompleteType="password"
             textContentType="password"
-            onKeyPress={(e) => handleEnter(e, signIn)}
+            onSubmitEditing={signIn}
             value={pass}
             onChange={(e) => setPass(e.nativeEvent.text)}
             secureTextEntry

--- a/src/screens/auth/Login.tsx
+++ b/src/screens/auth/Login.tsx
@@ -113,7 +113,11 @@ export default function Login({ navigation }: Params): JSX.Element {
     if (route.params?.newUser) {
       setError(accountVerifiedMessage);
     }
-  }, [route.params?.newUser]);
+
+    if (route.params?.email) {
+      setUser(route.params.email);
+    }
+  }, [route.params?.newUser, route.params?.email]);
 
   function navigateInAuthStack(screen: keyof AuthStackParamList): void {
     setUser('');

--- a/src/screens/auth/SignUp.tsx
+++ b/src/screens/auth/SignUp.tsx
@@ -11,7 +11,7 @@ import {
   StatusBar,
 } from 'react-native';
 import { Auth } from '@aws-amplify/auth';
-import { AntDesign, Entypo } from '@expo/vector-icons';
+import { AntDesign } from '@expo/vector-icons';
 import { StackNavigationProp } from '@react-navigation/stack';
 import {
   RouteProp,
@@ -20,6 +20,7 @@ import {
 } from '@react-navigation/native';
 import { Thumbnail, Button } from 'native-base';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import PasswordRequirements from '../../components/auth/PasswordRequirements';
 import { MainStackParamList } from '../../navigation/AppNavigator';
 import { AuthStackParamList } from '../../navigation/AuthNavigator';
 import NoMedia from '../../components/NoMedia';
@@ -102,49 +103,6 @@ const style = StyleSheet.create({
   },
 });
 
-interface PasswordIconParams {
-  meetsRequirement: boolean;
-  requirement: string;
-}
-
-function PasswordRequirement({
-  meetsRequirement,
-  requirement,
-}: PasswordIconParams) {
-  return (
-    <View
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        marginBottom: 4,
-        backgroundColor: Theme.colors.grey1,
-        paddingRight: 10,
-        paddingLeft: 6,
-        borderRadius: 40,
-        marginRight: 8,
-        paddingVertical: 4,
-      }}
-    >
-      {meetsRequirement ? (
-        <Entypo name="check" size={14} color={Theme.colors.green} />
-      ) : (
-        <Entypo name="cross" size={14} color={Theme.colors.red} />
-      )}
-      <Text
-        style={{
-          color: 'white',
-          fontFamily: Theme.fonts.fontFamilyRegular,
-          fontSize: 14,
-          marginLeft: 4,
-        }}
-      >
-        {requirement}
-      </Text>
-    </View>
-  );
-}
-
 interface Params {
   navigation: CompositeNavigationProp<
     StackNavigationProp<AuthStackParamList>,
@@ -155,7 +113,10 @@ interface Params {
 export default function SignUp({ navigation }: Params): JSX.Element {
   const [user, setUser] = useState('');
   const [pass, setPass] = useState('');
-  const [site, setSite] = useState({ locationName: '', locationId: '' });
+  const [site, setSite] = useState({
+    locationName: 'unknown',
+    locationId: 'unknown',
+  });
   const [error, setError] = useState('');
   const route = useRoute<RouteProp<AuthStackParamList, 'SignUpScreen'>>();
   const safeArea = useSafeAreaInsets();
@@ -175,14 +136,14 @@ export default function SignUp({ navigation }: Params): JSX.Element {
   function navigateInAuthStack(screen: keyof AuthStackParamList): void {
     setUser('');
     setPass('');
-    setSite({ locationName: '', locationId: '' });
+    setSite({ locationName: 'unknown', locationId: 'unknown' });
     setError('');
     navigation.push(screen);
   }
 
   function confirmUser(): void {
     setPass('');
-    setSite({ locationName: '', locationId: '' });
+    setSite({ locationName: 'unknown', locationId: 'unknown' });
     setError('');
     navigation.push('ConfirmSignUpScreen', { email: user });
   }
@@ -190,7 +151,7 @@ export default function SignUp({ navigation }: Params): JSX.Element {
   function navigateHome() {
     setUser('');
     setPass('');
-    setSite({ locationName: '', locationId: '' });
+    setSite({ locationName: 'unknown', locationId: 'unknown' });
     setError('');
     navigation.push('Main', {
       screen: 'Home',
@@ -298,52 +259,16 @@ export default function SignUp({ navigation }: Params): JSX.Element {
             secureTextEntry
             style={style.input}
           />
-          <View
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              alignItems: 'center',
-              marginTop: 12,
-            }}
-          >
-            <Text
-              style={{
-                color: 'white',
-                fontFamily: Theme.fonts.fontFamilyBold,
-                fontSize: 14,
-                marginRight: 8,
-              }}
-            >
-              Password must contain at least:
-            </Text>
-            <PasswordRequirement
-              meetsRequirement={pass.length >= 8}
-              requirement="8 characters"
-            />
-            <PasswordRequirement
-              meetsRequirement={/(?=.*[A-Z])/.test(pass)}
-              requirement="upper &amp; lowercase letters"
-            />
-            <PasswordRequirement
-              meetsRequirement={/(?=.*[0-9])/.test(pass)}
-              requirement="1 number"
-            />
-            <PasswordRequirement
-              // eslint-disable-next-line no-useless-escape
-              meetsRequirement={/(?=.*[\=\+\$\*\.\,\?\"\!\@\#\%\&\'\:\;\[\]\{\}\(\)\/\\\>\<\|\_\~\`\^\-])/.test(
-                pass
-              )}
-              requirement="1 special character (e.g. @ ! $ ^ ?)"
-            />
-          </View>
+          <PasswordRequirements password={pass} />
           <Text style={style.title}>Choose Your Location</Text>
           <TouchableOpacity
             style={style.locationSelector}
             onPress={() => navigation.push('LocationSelectionScreen')}
           >
             <Text style={style.locationText}>
-              {site.locationName ? site.locationName : 'None Selected'}
+              {site.locationName && site.locationName !== 'unknown'
+                ? site.locationName
+                : 'None Selected'}
             </Text>
             <AntDesign name="caretdown" size={8} color="white" />
           </TouchableOpacity>

--- a/src/screens/auth/SignUp.tsx
+++ b/src/screens/auth/SignUp.tsx
@@ -4,8 +4,6 @@ import {
   View,
   Text,
   TextInput,
-  NativeSyntheticEvent,
-  TextInputKeyPressEventData,
   TouchableOpacity,
   ScrollView,
   Dimensions,
@@ -199,13 +197,6 @@ export default function SignUp({ navigation }: Params): JSX.Element {
     });
   }
 
-  function handleEnter(
-    keyEvent: NativeSyntheticEvent<TextInputKeyPressEventData>,
-    cb: () => void
-  ): void {
-    if (keyEvent.nativeEvent.key === 'Enter') cb();
-  }
-
   const signUp = async () => {
     const regex = /\S+@\S+\.\S+/;
     if (!regex.test(user)) {
@@ -301,7 +292,7 @@ export default function SignUp({ navigation }: Params): JSX.Element {
             textContentType="newPassword"
             passwordRules="required: lower; required: upper; required: digit; required: special; minlength: 8;"
             keyboardAppearance="dark"
-            onKeyPress={(e) => handleEnter(e, signUp)}
+            onSubmitEditing={signUp}
             value={pass}
             onChange={(e) => setPass(e.nativeEvent.text)}
             secureTextEntry

--- a/src/screens/profile/AccountScreen.tsx
+++ b/src/screens/profile/AccountScreen.tsx
@@ -158,6 +158,8 @@ export default function Account({ navigation }: Params): JSX.Element {
     });
   }, [navigation]);
 
+  const homeLocation = user?.userData?.['custom:home_location'];
+
   const items = [
     'Login',
     {
@@ -176,11 +178,10 @@ export default function Account({ navigation }: Params): JSX.Element {
       id: 'loc',
       text: 'Location',
       icon: Theme.icons.grey.arrow,
-      data: user?.userData?.['custom:home_location']
-        ? LocationsService.mapLocationIdToName(
-            user?.userData?.['custom:home_location']
-          )
-        : 'None Selected',
+      data:
+        homeLocation && homeLocation !== 'unknown'
+          ? LocationsService.mapLocationIdToName(homeLocation)
+          : 'None Selected',
       action: () =>
         navigation.navigate('LocationSelectionScreen', { persist: true }),
     },

--- a/src/screens/profile/ChangePasswordScreen.tsx
+++ b/src/screens/profile/ChangePasswordScreen.tsx
@@ -24,6 +24,7 @@ import {
   CompositeNavigationProp,
 } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import PasswordRequirements from '../../components/auth/PasswordRequirements';
 import UserContext, { TMHCognitoUser } from '../../contexts/UserContext';
 import { HomeStackParamList } from '../../navigation/MainTabNavigator';
 import { MainStackParamList } from '../../navigation/AppNavigator';
@@ -291,6 +292,10 @@ export default function ChangePass({ navigation }: Params): JSX.Element {
                 </Text>
               </View>
             </List>
+            <PasswordRequirements
+              password={newPass}
+              style={{ marginHorizontal: '5%' }}
+            />
           </View>
         </Content>
       </Container>

--- a/src/services/LocationsService.ts
+++ b/src/services/LocationsService.ts
@@ -35,7 +35,7 @@ const locations: { [key: string]: string } = {
   'richmond-hill': 'Richmond Hill',
   'toronto-uptown': 'Toronto - Uptown',
   waterloo: 'Waterloo',
-  unknown: '',
+  unknown: 'unknown',
 };
 
 export default class LocationsService {


### PR DESCRIPTION
A few UX improvements related to sign-up/sign-in and password creation:


* I originally used the `onKeyPress` prop to submit forms if the key code is `"Enter"`, which is not very reliable. Now uses the `onSubmitEditing` prop, so the forms actually submit when you press enter/return.
* I componentized password requirements and added it to the forgot password and change password forms.
* Where possible, the user's email address is pre-filled on the login screen (see the `email` route param for LoginScreen).
* Fixes a bug, where the user's location saved as an empty string instead of `"unknown"` if they do not select a location.



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=645651549)
