### PR TITLE
Change Regex for pulling URL from event description

### DIFF
--- a/src/screens/home/EventDetailsScreen.tsx
+++ b/src/screens/home/EventDetailsScreen.tsx
@@ -304,7 +304,7 @@ export default function EventDetailsScreen({
     let linkAddress = '';
     if (eventItem?.description?.includes('https://')) {
       linkAddress =
-        eventItem?.description?.match(/(https?:\/\/[^ ]*)/)?.[1] ?? '';
+        eventItem?.description?.match(/(https?:\/\/[^\\w\s]*)/)?.[0] ?? '';
     }
     return linkAddress;
   };


### PR DESCRIPTION
* Now also accounts for \t and \n



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=648187758)
