### PR TITLE
Home Church

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
         "react-native-expo-cached-image": "^1.3.1",
         "react-native-gesture-handler": "~1.8.0",
+        "react-native-maps": "0.27.1",
         "react-native-open-maps": "^0.3.5",
         "react-native-reanimated": "~1.13.0",
         "react-native-safe-area-context": "3.1.9",
@@ -31362,6 +31363,16 @@
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
       "peerDependencies": {
         "react-native": ">=0.42.0"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.27.1.tgz",
+      "integrity": "sha512-HygBkZBecTnIVRYrSiLRAvu4OmXOYso/A7c6Cy73HkOh9CgGV8Ap5eBea24tvmFGptjj5Hg8AJ94/YbmWK1Okw==",
+      "peerDependencies": {
+        "prop-types": "^15.0 || ^16.0",
+        "react": ">= 16.0 || < 17.0",
+        "react-native": ">= 0.51"
       }
     },
     "node_modules/react-native-open-maps": {
@@ -64123,6 +64134,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
+    },
+    "react-native-maps": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-0.27.1.tgz",
+      "integrity": "sha512-HygBkZBecTnIVRYrSiLRAvu4OmXOYso/A7c6Cy73HkOh9CgGV8Ap5eBea24tvmFGptjj5Hg8AJ94/YbmWK1Okw==",
       "requires": {}
     },
     "react-native-open-maps": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-font": "~8.4.0",
     "expo-linear-gradient": "~8.4.0",
     "expo-linking": "~2.0.0",
+    "expo-location": "~10.0.0",
     "expo-notifications": "~0.8.2",
     "expo-permissions": "~10.0.0",
     "expo-random": "~10.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-40.0.1.tar.gz",
     "react-native-expo-cached-image": "^1.3.1",
     "react-native-gesture-handler": "~1.8.0",
+    "react-native-maps": "0.27.1",
     "react-native-open-maps": "^0.3.5",
     "react-native-reanimated": "~1.13.0",
     "react-native-safe-area-context": "3.1.9",

--- a/src/Theme.style.ts
+++ b/src/Theme.style.ts
@@ -7,6 +7,7 @@ import UserWhite from '../assets/images/white/User.png';
 import NotesWhite from '../assets/images/white/Notes.png';
 import CalendarAddWhite from '../assets/images/white/Calendar-Add.png';
 import MapLocationWhite from '../assets/images/white/Map-Location.png';
+import Location from '../assets/images/white/Location.png';
 import AnnouncementWhite from '../assets/images/white/Announcement.png';
 import SearchWhite from '../assets/images/white/Search.png';
 import CheckWhite from '../assets/images/white/Check.png';
@@ -102,6 +103,7 @@ export const Theme = {
       notes: NotesWhite,
       calendarAdd: CalendarAddWhite,
       mapLocation: MapLocationWhite,
+      location: Location,
       announcement: AnnouncementWhite,
       search: SearchWhite,
       check: CheckWhite,

--- a/src/Theme.style.ts
+++ b/src/Theme.style.ts
@@ -7,6 +7,7 @@ import UserWhite from '../assets/images/white/User.png';
 import NotesWhite from '../assets/images/white/Notes.png';
 import CalendarAddWhite from '../assets/images/white/Calendar-Add.png';
 import MapLocationWhite from '../assets/images/white/Map-Location.png';
+import MapIconBlack from '../assets/images/black/Map.png';
 import Location from '../assets/images/white/Location.png';
 import AnnouncementWhite from '../assets/images/white/Announcement.png';
 import SearchWhite from '../assets/images/white/Search.png';
@@ -149,6 +150,7 @@ export const Theme = {
       arrow: Arrow,
       audio: AudioBlack,
       watch: WatchBlack,
+      map: MapIconBlack,
       twitter: Twitter,
       facebook: Facebook,
       share: ShareBlack,

--- a/src/Theme.style.ts
+++ b/src/Theme.style.ts
@@ -20,6 +20,7 @@ import StaffWhite from '../assets/images/white/Staff.png';
 import HomeChurchWhite from '../assets/images/white/HomeChurch.png';
 import TextOptionsWhite from '../assets/images/white/TextOptions.png';
 import NewWindowWhite from '../assets/images/white/New-Window.png';
+import FamilyFriendly from '../assets/images/black/FamilyFriendly.png';
 import UserWhiteLoggedIn from '../assets/images/white/UserLoggedIn.png';
 import SignOutWhite from '../assets/images/white/SignOut.png';
 import AccountWhite from '../assets/images/white/Account.png';
@@ -142,6 +143,7 @@ export const Theme = {
       comment: CommentSmall,
     },
     black: {
+      familyFriendly: FamilyFriendly,
       arrow: Arrow,
       audio: AudioBlack,
       watch: WatchBlack,

--- a/src/Theme.style.ts
+++ b/src/Theme.style.ts
@@ -20,6 +20,7 @@ import VolunteerWhite from '../assets/images/white/Volunteer.png';
 import ConnectWhite from '../assets/images/white/Connect.png';
 import StaffWhite from '../assets/images/white/Staff.png';
 import HomeChurchWhite from '../assets/images/white/HomeChurch.png';
+import HomeChurchBlack from '../assets/images/black/HomeChurch.png';
 import TextOptionsWhite from '../assets/images/white/TextOptions.png';
 import NewWindowWhite from '../assets/images/white/New-Window.png';
 import FamilyFriendly from '../assets/images/black/FamilyFriendly.png';
@@ -150,6 +151,7 @@ export const Theme = {
       arrow: Arrow,
       audio: AudioBlack,
       watch: WatchBlack,
+      homeChurch: HomeChurchBlack,
       map: MapIconBlack,
       twitter: Twitter,
       facebook: Facebook,

--- a/src/components/home/HomeChurchCard.tsx
+++ b/src/components/home/HomeChurchCard.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { StyleSheet, View, Text, Image } from 'react-native';
+import Theme, { Style } from '../../Theme.style';
+import AllButton from '../buttons/AllButton';
+
+const style = StyleSheet.create({
+  homeChurchContainer: {
+    backgroundColor: Theme.colors.black,
+  },
+  categoryTitle: {
+    ...Style.categoryTitle,
+    marginBottom: 0,
+    paddingBottom: 0,
+  },
+  imageContainer: {
+    height: 256,
+    flex: 1,
+  },
+  picture: {
+    marginVertical: 0,
+    paddingVertical: 0,
+    flex: 1,
+  },
+  title: {
+    color: 'white',
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    fontSize: 24,
+    lineHeight: 32,
+    marginHorizontal: 16,
+    marginBottom: 16,
+  },
+  paragraph: {
+    color: 'white',
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    fontSize: 16,
+    lineHeight: 24,
+    marginHorizontal: 16,
+    marginBottom: 24,
+  },
+});
+
+export default function HomeChurchCard(): JSX.Element {
+  return (
+    <View style={style.homeChurchContainer}>
+      <Text style={style.categoryTitle}>Home Church</Text>
+      <View style={style.imageContainer}>
+        <Image
+          resizeMode="contain"
+          style={style.picture}
+          accessibilityLabel="Home Church Image"
+          source={{
+            uri:
+              'https://www.themeetinghouse.com/cached/640/static/images/homechurch-1-1.jpg',
+            cache: 'reload',
+          }}
+        />
+      </View>
+      <Text style={style.title}>Get connected to community near you.</Text>
+      <Text style={style.paragraph}>
+        It’s pretty simple: we get together each week to hang out, build
+        relationships, and find ways to love and serve our local communities, as
+        we learn to follow Jesus.
+      </Text>
+      <AllButton handlePress={() => console.log('navigate')}>
+        Find a Home Church
+      </AllButton>
+    </View>
+  );
+}

--- a/src/components/home/HomeChurchCard.tsx
+++ b/src/components/home/HomeChurchCard.tsx
@@ -20,6 +20,7 @@ const style = StyleSheet.create({
     flex: 1,
   },
   picture: {
+    marginLeft: 16,
     marginVertical: 0,
     paddingVertical: 0,
     flex: 1,
@@ -54,7 +55,7 @@ export default function HomeChurchCard(): JSX.Element {
           accessibilityLabel="Home Church Image"
           source={{
             uri:
-              'https://www.themeetinghouse.com/cached/640/static/images/homechurch-1-1.jpg',
+              'https://www.themeetinghouse.com/cached/640/static/images/homechurch-2-1.jpg',
             cache: 'default',
           }}
         />

--- a/src/components/home/HomeChurchCard.tsx
+++ b/src/components/home/HomeChurchCard.tsx
@@ -55,7 +55,7 @@ export default function HomeChurchCard(): JSX.Element {
           accessibilityLabel="Home Church Image"
           source={{
             uri:
-              'https://www.themeetinghouse.com/cached/640/static/images/homechurch-2-1.jpg',
+              'https://www.themeetinghouse.com/static/images/homechurch-2-1.jpg',
             cache: 'default',
           }}
         />
@@ -66,7 +66,9 @@ export default function HomeChurchCard(): JSX.Element {
         relationships, and find ways to love and serve our local communities, as
         we learn to follow Jesus.
       </Text>
-      <AllButton handlePress={() => navigation.navigate('HomeChurchScreen')}>
+      <AllButton
+        handlePress={() => navigation.navigate('HomeChurchScreen', {})}
+      >
         Find a Home Church
       </AllButton>
     </View>

--- a/src/components/home/HomeChurchCard.tsx
+++ b/src/components/home/HomeChurchCard.tsx
@@ -1,5 +1,8 @@
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
 import React from 'react';
 import { StyleSheet, View, Text, Image } from 'react-native';
+import { MainStackParamList } from 'src/navigation/AppNavigator';
 import Theme, { Style } from '../../Theme.style';
 import AllButton from '../buttons/AllButton';
 
@@ -40,6 +43,7 @@ const style = StyleSheet.create({
 });
 
 export default function HomeChurchCard(): JSX.Element {
+  const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
   return (
     <View style={style.homeChurchContainer}>
       <Text style={style.categoryTitle}>Home Church</Text>
@@ -51,7 +55,7 @@ export default function HomeChurchCard(): JSX.Element {
           source={{
             uri:
               'https://www.themeetinghouse.com/cached/640/static/images/homechurch-1-1.jpg',
-            cache: 'reload',
+            cache: 'default',
           }}
         />
       </View>
@@ -61,7 +65,7 @@ export default function HomeChurchCard(): JSX.Element {
         relationships, and find ways to love and serve our local communities, as
         we learn to follow Jesus.
       </Text>
-      <AllButton handlePress={() => console.log('navigate')}>
+      <AllButton handlePress={() => navigation.navigate('HomeChurchScreen')}>
         Find a Home Church
       </AllButton>
     </View>

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -28,6 +28,7 @@ import AskAQuestion from '../screens/home/AskAQuestion';
 import { EventQueryResult } from '../services/EventsService';
 import MyComments from '../screens/comments/MyComments';
 import HomeChurchScreen from '../screens/homechurch/HomeChurchScreen';
+import HomeChurchMapScreen from '../screens/homechurch/HomeChurchMapScreen';
 
 export type MainStackParamList = {
   Main:
@@ -82,6 +83,7 @@ export type MainStackParamList = {
         commentType: CommentDataType;
         noteId: string;
       };
+  HomeChurchMapScreen: any;
 };
 
 const Main = createStackNavigator<MainStackParamList>();
@@ -122,6 +124,7 @@ export default function NavigationRoot(): JSX.Element {
       <Main.Screen name="HomeChurchScreen" component={HomeChurchScreen} />
       <Main.Screen name="LiveStreamScreen" component={LiveStreamScreen} />
       <Main.Screen name="TeacherList" component={TeacherList} />
+      <Main.Screen name="HomeChurchMapScreen" component={HomeChurchMapScreen} />
     </Main.Navigator>
   );
 }

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
+import { LocationData } from 'src/contexts/LocationContext';
 import MainTabNavigator, {
   TabNavigatorParamList,
   HomeStackParamList,
@@ -31,6 +32,7 @@ import HomeChurchScreen, {
   HomeChurchData,
 } from '../screens/homechurch/HomeChurchScreen';
 import HomeChurchMapScreen from '../screens/homechurch/HomeChurchMapScreen';
+import HomeChurchLocationSelect from '../screens/homechurch/HomeChurchLocationSelect';
 
 export type MainStackParamList = {
   Main:
@@ -56,6 +58,7 @@ export type MainStackParamList = {
   AccountScreen: undefined;
   ChangePasswordScreen: undefined;
   LocationSelectionScreen: { persist: boolean };
+  HomeChurchLocationSelect: { loc?: LocationData };
   HighlightScreen: { highlights: any[]; nextToken: string | undefined };
   DateRangeSelectScreen: undefined;
   SermonLandingScreen: {
@@ -66,7 +69,7 @@ export type MainStackParamList = {
   AllEvents: { events: NonNullable<EventQueryResult> };
   LiveStreamScreen: undefined;
   TeacherList: undefined;
-  HomeChurchScreen: undefined;
+  HomeChurchScreen: { loc?: LocationData };
   CommentScreen:
     | {
         key: string;
@@ -124,6 +127,10 @@ export default function NavigationRoot(): JSX.Element {
       <Main.Screen name="CommentScreen" component={CommentScreen} />
       <Main.Screen name="MyComments" component={MyComments} />
       <Main.Screen name="HomeChurchScreen" component={HomeChurchScreen} />
+      <Main.Screen
+        name="HomeChurchLocationSelect"
+        component={HomeChurchLocationSelect}
+      />
       <Main.Screen name="LiveStreamScreen" component={LiveStreamScreen} />
       <Main.Screen name="TeacherList" component={TeacherList} />
       <Main.Screen name="HomeChurchMapScreen" component={HomeChurchMapScreen} />

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -27,6 +27,7 @@ import TeacherProfile from '../screens/staff/TeacherProfile';
 import AskAQuestion from '../screens/home/AskAQuestion';
 import { EventQueryResult } from '../services/EventsService';
 import MyComments from '../screens/comments/MyComments';
+import HomeChurchScreen from '../screens/homechurch/HomeChurchScreen';
 
 export type MainStackParamList = {
   Main:
@@ -62,6 +63,7 @@ export type MainStackParamList = {
   AllEvents: { events: NonNullable<EventQueryResult> };
   LiveStreamScreen: undefined;
   TeacherList: undefined;
+  HomeChurchScreen: undefined;
   CommentScreen:
     | {
         key: string;
@@ -117,6 +119,7 @@ export default function NavigationRoot(): JSX.Element {
       <Main.Screen name="ParishTeam" component={ParishTeam} />
       <Main.Screen name="CommentScreen" component={CommentScreen} />
       <Main.Screen name="MyComments" component={MyComments} />
+      <Main.Screen name="HomeChurchScreen" component={HomeChurchScreen} />
       <Main.Screen name="LiveStreamScreen" component={LiveStreamScreen} />
       <Main.Screen name="TeacherList" component={TeacherList} />
     </Main.Navigator>

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -27,7 +27,9 @@ import TeacherProfile from '../screens/staff/TeacherProfile';
 import AskAQuestion from '../screens/home/AskAQuestion';
 import { EventQueryResult } from '../services/EventsService';
 import MyComments from '../screens/comments/MyComments';
-import HomeChurchScreen from '../screens/homechurch/HomeChurchScreen';
+import HomeChurchScreen, {
+  HomeChurchData,
+} from '../screens/homechurch/HomeChurchScreen';
 import HomeChurchMapScreen from '../screens/homechurch/HomeChurchMapScreen';
 
 export type MainStackParamList = {
@@ -83,7 +85,7 @@ export type MainStackParamList = {
         commentType: CommentDataType;
         noteId: string;
       };
-  HomeChurchMapScreen: any;
+  HomeChurchMapScreen: { items: HomeChurchData };
 };
 
 const Main = createStackNavigator<MainStackParamList>();

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -22,11 +22,13 @@ import * as Linking from 'expo-linking';
 import { CompositeNavigationProp, RouteProp } from '@react-navigation/native';
 import { API, GraphQLResult, graphqlOperation } from '@aws-amplify/api';
 import { Theme, Style, HeaderStyle } from '../../Theme.style';
-import AnnouncementCard from "../../components/home/AnnouncementCard";
-import AnnouncementService, { Announcement } from "../../services/AnnouncementService";
+import AnnouncementCard from '../../components/home/AnnouncementCard';
+import AnnouncementService, {
+  Announcement,
+} from '../../services/AnnouncementService';
 import EventCard from '../../components/home/EventCard';
 import RecentTeaching from '../../components/home/RecentTeaching';
-import EventsService, {EventQueryResult} from '../../services/EventsService';
+import EventsService, { EventQueryResult } from '../../services/EventsService';
 import ActivityIndicator from '../../components/ActivityIndicator';
 import LocationContext from '../../contexts/LocationContext';
 import { Location } from '../../services/LocationsService';
@@ -40,7 +42,7 @@ import LiveEventService from '../../services/LiveEventService';
 import UserContext from '../../contexts/UserContext';
 import { MainStackParamList } from '../../navigation/AppNavigator';
 import Header from '../../components/Header';
-import QuestionSuccessModal from "../../components/modals/QuestionSuccessModal";
+import QuestionSuccessModal from '../../components/modals/QuestionSuccessModal';
 import {
   GetNotesQuery,
   GetVideoByVideoTypeQueryVariables,
@@ -50,6 +52,7 @@ import {
 import { VideoData } from '../../utils/types';
 import NotesService from '../../services/NotesService';
 import { getVideoByVideoType } from '../../graphql/queries';
+import HomeChurchCard from '../../components/home/HomeChurchCard';
 
 const style = StyleSheet.create({
   categoryContainer: {
@@ -182,10 +185,8 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
         id: location?.locationData?.locationId,
         name: location?.locationData?.locationName,
       } as Location);
-      if (announcementsResult)
-        setAnnouncements(announcementsResult)
-
-    }
+      if (announcementsResult) setAnnouncements(announcementsResult);
+    };
     loadAnnouncements();
 
     const loadInstagramImages = async () => {
@@ -213,9 +214,9 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
     };
     if (locationId !== 'unknown' || locationName !== 'unknown') loadEvents();
   }, [locationId, locationName]);
-  
+
   const sendQuestion = () => {
-    navigation.navigate('AskAQuestion')
+    navigation.navigate('AskAQuestion');
   };
 
   useEffect(() => {
@@ -312,12 +313,12 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
     };
     load();
   }, []);
-  useEffect(()=>{
-      if(route.params?.questionResult){
-        setShowQuestionModal(route.params?.questionResult)
-        navigation.setParams({questionResult:false})
-      }
-  },[route.params?.questionResult, navigation])
+  useEffect(() => {
+    if (route.params?.questionResult) {
+      setShowQuestionModal(route.params?.questionResult);
+      navigation.setParams({ questionResult: false });
+    }
+  }, [route.params?.questionResult, navigation]);
   return (
     <Container>
       {preLive || live ? (
@@ -325,7 +326,11 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
           message={preLive ? 'We will be going live soon!' : 'We are live now!'}
         />
       ) : null}
-      {showQuestionModal ? <QuestionSuccessModal setShow={setShowQuestionModal}></QuestionSuccessModal> : null}
+      {showQuestionModal ? (
+        <QuestionSuccessModal
+          setShow={setShowQuestionModal}
+        ></QuestionSuccessModal>
+      ) : null}
       <Content style={{ backgroundColor: Theme.colors.background, flex: 1 }}>
         <View style={style.categoryContainer}>
           <RecentTeaching teaching={teaching} note={note} />
@@ -339,14 +344,23 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
           </View>
         </View>
         <View style={style.categoryContainer}>
-          {announcements.length > 0 ? announcements.map((announcement: Announcement) => (
-            <AnnouncementCard
-              key={announcement?.id}
-              announcement={announcement}
-              handlePress={() =>
-                navigation.push('AnnouncementDetailsScreen', { item: announcement as Announcement })
-              } />
-          )) : announcements.length === 0 ? null : <View><ActivityIndicator></ActivityIndicator></View>}
+          {announcements.length > 0 ? (
+            announcements.map((announcement: Announcement) => (
+              <AnnouncementCard
+                key={announcement?.id}
+                announcement={announcement}
+                handlePress={() =>
+                  navigation.push('AnnouncementDetailsScreen', {
+                    item: announcement as Announcement,
+                  })
+                }
+              />
+            ))
+          ) : announcements.length === 0 ? null : (
+            <View>
+              <ActivityIndicator></ActivityIndicator>
+            </View>
+          )}
         </View>
         {locationId !== 'unknown' || locationName !== 'unknown' ? (
           <View style={style.categoryContainer}>
@@ -360,26 +374,29 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
                   <>
                     <Text style={style.categoryTitle}>Upcoming Events</Text>
                     {events.map((event, index: number) => {
-                      if(index < 3) 
-                       return <EventCard
-                        key={event?.id}
-                        event={event}
-                        handlePress={() =>
-                          navigation.navigate('EventDetailsScreen', {
-                            item: event,
-                          })
-                        }
-                      />
+                      if (index < 3)
+                        return (
+                          <EventCard
+                            key={event?.id}
+                            event={event}
+                            handlePress={() =>
+                              navigation.navigate('EventDetailsScreen', {
+                                item: event,
+                              })
+                            }
+                          />
+                        );
                       else return null;
-                      })}
-                    {events.length > 3 ?
-                    <AllButton
-                      handlePress={() => {
-                      navigation.navigate('AllEvents', {events:events});
-                      }}
-                    >
-                      See All Events
-                    </AllButton> : null}
+                    })}
+                    {events.length > 3 ? (
+                      <AllButton
+                        handlePress={() => {
+                          navigation.navigate('AllEvents', { events: events });
+                        }}
+                      >
+                        See All Events
+                      </AllButton>
+                    ) : null}
                   </>
                 ) : (
                   <Text style={style.categoryTitle}>No Upcoming Events</Text>
@@ -388,6 +405,8 @@ export default function HomeScreen({ navigation, route }: Params): JSX.Element {
             )}
           </View>
         ) : null}
+
+        <HomeChurchCard />
 
         {/* This should fallback to main TMH Site instead */}
         {images && images.length > 1 ? (

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -25,30 +25,28 @@ const HomeChurchConfirmationModal = ({
   getDayOfWeek,
   type,
 }: Params): JSX.Element => {
+  const startTime =
+    moment() < moment().isoWeekday(getDayOfWeek(homeChurch))
+      ? moment()
+          .isoWeekday(getDayOfWeek(homeChurch))
+          .set({
+            hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+            minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+            second: moment(homeChurch?.schedule?.startTime).get('second'),
+          })
+      : moment()
+          .isoWeekday(getDayOfWeek(homeChurch))
+          .add(7, 'days')
+          .set({
+            hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+            minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+            second: moment(homeChurch?.schedule?.startTime).get('second'),
+          });
   const [open] = useState(true);
   const addToCalendar = async () => {
-    let startTime;
-    if (moment() < moment().isoWeekday(getDayOfWeek(homeChurch))) {
-      startTime = moment()
-        .isoWeekday(getDayOfWeek(homeChurch))
-        .set({
-          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
-          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
-          second: moment(homeChurch?.schedule?.startTime).get('second'),
-        });
-    } else {
-      startTime = moment()
-        .isoWeekday(getDayOfWeek(homeChurch))
-        .add(7, 'days')
-        .set({
-          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
-          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
-          second: moment(homeChurch?.schedule?.startTime).get('second'),
-        });
-    }
     const endTime = moment(startTime).add(2, 'hours');
     try {
-      const createEntry = await Calendar.createEvent(
+      await Calendar.createEvent(
         {
           name: homeChurch?.name,
           place: {
@@ -137,33 +135,9 @@ const HomeChurchConfirmationModal = ({
               <>
                 This will add a single entry to your calendar for{' '}
                 <Text style={{ fontFamily: Theme.fonts.fontFamilyBold }}>
-                  {moment()
-                    .isoWeekday(getDayOfWeek(homeChurch))
-                    .set({
-                      hour: moment(homeChurch?.schedule?.startTime).get('hour'),
-                      minute: moment(homeChurch?.schedule?.startTime).get(
-                        'minute'
-                      ),
-                      second: moment(homeChurch?.schedule?.startTime).get(
-                        'second'
-                      ),
-                    })
-                    .format('dddd, MMM DD h:mm a')}{' '}
-                  -{' '}
-                  {moment()
-                    .isoWeekday(getDayOfWeek(homeChurch))
-                    .set({
-                      hour: moment(homeChurch?.schedule?.startTime)
-                        .add(2, 'hours')
-                        .get('hour'),
-                      minute: moment(homeChurch?.schedule?.startTime).get(
-                        'minute'
-                      ),
-                      second: moment(homeChurch?.schedule?.startTime).get(
-                        'second'
-                      ),
-                    })
-                    .format('h:mm a')}
+                  {startTime.format('dddd, MMM DD')} from{' '}
+                  {startTime.format('hh:mm')} -{' '}
+                  {startTime.add(2, 'hours').format('h:mm a')}
                 </Text>
               </>
             ) : (

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -1,0 +1,195 @@
+import moment from 'moment';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  Image,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
+import WhiteButton from '../../../src/components/buttons/WhiteButton';
+import Calendar from '../../services/CalendarService';
+import Theme from '../../Theme.style';
+import { HomeChurch } from './HomeChurchScreen';
+
+interface Params {
+  homeChurch: HomeChurch;
+  handleClose: () => void;
+  getDayOfWeek: (homeChurch: HomeChurch) => string;
+  type: 'contact' | 'calendar' | '';
+}
+const HomeChurchConfirmationModal = ({
+  homeChurch,
+  handleClose,
+  getDayOfWeek,
+  type,
+}: Params): JSX.Element => {
+  const [open] = useState(true);
+  const addToCalendar = async () => {
+    let startTime;
+    if (moment() < moment().isoWeekday(getDayOfWeek(homeChurch))) {
+      startTime = moment()
+        .isoWeekday(getDayOfWeek(homeChurch))
+        .set({
+          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+          second: moment(homeChurch?.schedule?.startTime).get('second'),
+        });
+    } else {
+      startTime = moment()
+        .isoWeekday(getDayOfWeek(homeChurch))
+        .add(7, 'days')
+        .set({
+          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+          second: moment(homeChurch?.schedule?.startTime).get('second'),
+        });
+    }
+    const endTime = moment(startTime).add(2, 'hours');
+    try {
+      const createEntry = await Calendar.createEvent(
+        {
+          name: homeChurch?.name,
+          place: {
+            location: {
+              street: homeChurch?.location?.address?.address1,
+            },
+          },
+        },
+        {
+          start_time: startTime.format(),
+          end_time: endTime.format(),
+        }
+      );
+    } catch (err) {
+      // error occurred
+    } finally {
+      // great success
+    }
+  };
+  return (
+    <Modal animationType="slide" visible={open} transparent>
+      <View
+        style={{
+          flex: 1,
+          justifyContent: 'center',
+          backgroundColor: 'rgba(0,0,0,.5)',
+        }}
+      >
+        <View
+          style={{
+            padding: 32,
+            width: '100%',
+            backgroundColor: 'white',
+            alignSelf: 'center',
+          }}
+        >
+          <View style={{ flexDirection: 'row' }}>
+            <Text
+              style={{
+                fontFamily: Theme.fonts.fontFamilyBold,
+                fontSize: 24,
+                width: '95%',
+                color: 'black',
+                textAlign: 'left',
+                marginBottom: 16,
+              }}
+            >
+              {type === 'contact'
+                ? `Send email to the leader of ${homeChurch?.name}`
+                : type === 'calendar'
+                ? `Add ${homeChurch?.name} to your calendar?`
+                : ''}
+            </Text>
+            <TouchableOpacity
+              style={{
+                marginTop: 6,
+                width: 27,
+                height: 24,
+              }}
+              onPress={() => {
+                handleClose();
+              }}
+            >
+              <Image
+                style={{
+                  width: 27,
+                  height: 24,
+                }}
+                source={Theme.icons.black.closeCancel}
+              />
+            </TouchableOpacity>
+          </View>
+          <Text
+            style={{
+              fontFamily: Theme.fonts.fontFamilyMedium,
+              fontSize: 16,
+              lineHeight: 24,
+              color: 'black',
+              textAlign: 'left',
+              marginBottom: 16,
+            }}
+          >
+            {type === 'contact' ? (
+              `This will open your default email client to compose a new message.`
+            ) : type === 'calendar' ? (
+              <>
+                This will add a single entry to your calendar for{' '}
+                <Text style={{ fontFamily: Theme.fonts.fontFamilyBold }}>
+                  {moment()
+                    .isoWeekday(getDayOfWeek(homeChurch))
+                    .set({
+                      hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+                      minute: moment(homeChurch?.schedule?.startTime).get(
+                        'minute'
+                      ),
+                      second: moment(homeChurch?.schedule?.startTime).get(
+                        'second'
+                      ),
+                    })
+                    .format('dddd, MMM DD h:mm a')}{' '}
+                  -{' '}
+                  {moment()
+                    .isoWeekday(getDayOfWeek(homeChurch))
+                    .set({
+                      hour: moment(homeChurch?.schedule?.startTime)
+                        .add(2, 'hours')
+                        .get('hour'),
+                      minute: moment(homeChurch?.schedule?.startTime).get(
+                        'minute'
+                      ),
+                      second: moment(homeChurch?.schedule?.startTime).get(
+                        'second'
+                      ),
+                    })
+                    .format('h:mm a')}
+                </Text>
+              </>
+            ) : (
+              ''
+            )}
+          </Text>
+          <View style={{ height: 56, marginBottom: 16, marginTop: 16 }}>
+            <WhiteButton
+              solidBlack
+              label="Yes"
+              onPress={async () => {
+                if (type === 'contact')
+                  Linking.openURL(
+                    `mailto:roger.massie@themeetinghouse.com?subject=Inquiry%20About%20Home%20Church&body=Home%20Church%20ID:%20${homeChurch?.id}`
+                  );
+                else if (type === 'calendar') await addToCalendar();
+                handleClose();
+              }}
+            />
+          </View>
+          <View style={{ borderWidth: 3, height: 56, marginBottom: 16 }}>
+            <WhiteButton label="Cancel" onPress={handleClose} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+export default homeChurchConfirmationModal;

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -192,4 +192,4 @@ const HomeChurchConfirmationModal = ({
     </Modal>
   );
 };
-export default homeChurchConfirmationModal;
+export default HomeChurchConfirmationModal;

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -97,7 +97,7 @@ const HomeChurchConfirmationModal = ({
               }}
             >
               {type === 'contact'
-                ? `Send email to the leader of ${homeChurch?.name}`
+                ? `Send email to the leader of ${homeChurch?.name}?`
                 : type === 'calendar'
                 ? `Add ${homeChurch?.name} to your calendar?`
                 : ''}

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -64,7 +64,6 @@ const HomeChurchConfirmationModal = ({
         });
     }
     const endTime = moment(astartTime).add(2, 'hours');
-    console.log(astartTime.format());
     try {
       await Calendar.createEvent(
         {

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -44,7 +44,27 @@ const HomeChurchConfirmationModal = ({
           });
   const [open] = useState(true);
   const addToCalendar = async () => {
-    const endTime = moment(startTime).add(2, 'hours');
+    let astartTime;
+    if (moment() < moment().isoWeekday(getDayOfWeek(homeChurch))) {
+      astartTime = moment()
+        .isoWeekday(getDayOfWeek(homeChurch))
+        .set({
+          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+          second: moment(homeChurch?.schedule?.startTime).get('second'),
+        });
+    } else {
+      astartTime = moment()
+        .isoWeekday(getDayOfWeek(homeChurch))
+        .add(7, 'days')
+        .set({
+          hour: moment(homeChurch?.schedule?.startTime).get('hour'),
+          minute: moment(homeChurch?.schedule?.startTime).get('minute'),
+          second: moment(homeChurch?.schedule?.startTime).get('second'),
+        });
+    }
+    const endTime = moment(astartTime).add(2, 'hours');
+    console.log(astartTime.format());
     try {
       await Calendar.createEvent(
         {
@@ -56,7 +76,7 @@ const HomeChurchConfirmationModal = ({
           },
         },
         {
-          start_time: startTime.format(),
+          start_time: astartTime.format(),
           end_time: endTime.format(),
         }
       );

--- a/src/screens/homechurch/HomeChurchConfirmationModal.tsx
+++ b/src/screens/homechurch/HomeChurchConfirmationModal.tsx
@@ -175,12 +175,12 @@ const HomeChurchConfirmationModal = ({
               solidBlack
               label="Yes"
               onPress={async () => {
-                if (type === 'contact')
-                  Linking.openURL(
+                if (type === 'contact') {
+                  await Linking.openURL(
                     `mailto:roger.massie@themeetinghouse.com?subject=Inquiry%20About%20Home%20Church&body=Home%20Church%20ID:%20${homeChurch?.id}`
                   );
-                else if (type === 'calendar') await addToCalendar();
-                handleClose();
+                  handleClose();
+                } else if (type === 'calendar') await addToCalendar();
               }}
             />
           </View>

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import {
+  StyleSheet,
+  TouchableWithoutFeedback,
+  TouchableOpacity,
+  View,
+  Text,
+  Dimensions,
+} from 'react-native';
+import { Thumbnail } from 'native-base';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { MainStackParamList } from '../../navigation/AppNavigator';
+import { LocationData } from '../../contexts/LocationContext';
+import { Theme, Style } from '../../Theme.style';
+import { TouchableHighlight } from 'react-native-gesture-handler';
+
+interface Params {
+  navigation: StackNavigationProp<MainStackParamList>;
+  loc: LocationData;
+  setDay: (day: string) => void;
+}
+const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element => {
+  const [selectedLocation, setSelectedLocation] = useState<LocationData>(
+    loc?.locationName === 'unknown' || !!!loc?.locationName ? { locationName: 'All Locations', locationId: "" } : { locationName: loc?.locationName, locationId: loc?.locationId }
+  );
+  const [weekday, setWeekDay] = useState('All Days');
+  const days = [
+    'All Days',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+    'Sunday',
+  ];
+  const [active, setActive] = useState(false);
+  const style = StyleSheet.create({
+    locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
+    container: {
+      backgroundColor: '#111111',
+      margin: 16,
+      width: Dimensions.get('window').width - 32,
+      position: 'relative'
+    },
+    containerItem: {
+      flexDirection: 'row',
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      paddingHorizontal: 20,
+      color: 'white',
+      minHeight: 56,
+      fontSize: 16,
+      borderWidth: 1,
+      borderColor: '#1A1A1A',
+    },
+    locationSelect: {
+      alignSelf: 'center',
+      flex: 1,
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      color: '#fff',
+      fontSize: 16,
+    },
+  });
+  const handleDrop = (day: string) => {
+    setWeekDay(day);
+    setDay(day);
+    setActive(false)
+  }
+  useEffect(() => {
+    setSelectedLocation(loc)
+  }, [loc])
+  return (
+    <>
+      <View style={style.container}>
+        <TouchableWithoutFeedback
+          onPress={() =>
+            navigation.push('HomeChurchLocationSelect', {})
+          }
+          style={style.containerItem}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              height: 56,
+              marginLeft: 16,
+            }}
+          >
+            <Thumbnail
+              style={style.locationIcon}
+              source={Theme.icons.white.location}
+              square
+            />
+            <Text style={style.locationSelect}>{selectedLocation?.locationName}</Text>
+          </View>
+        </TouchableWithoutFeedback>
+        <TouchableHighlight onBlur={() => setActive(false)} style={style.containerItem} onPress={() => setActive(!active)}>
+          <Text style={{ color: 'white', padding: 16 }}>{weekday}</Text>
+        </TouchableHighlight>
+
+        {active ? (
+          <View
+            style={{
+              backgroundColor: '#111111',
+              top: 56,
+              width: "100%",
+              position: 'absolute',
+              zIndex: 1000,
+            }}
+          >
+            {days.map((day) => (
+              <TouchableHighlight key={day} onPress={() => handleDrop(day)} style={style.containerItem}>
+                <Text style={{ color: 'white', padding: 16 }}>{day}</Text>
+              </TouchableHighlight>
+            ))}
+          </View>
+        ) : null}
+
+      </View>
+      <View style={{ zIndex: -100 }}>
+
+        <TouchableOpacity
+          style={{ zIndex: -100, backgroundColor: "grey", width: 100 }}
+          onPress={() => {
+            handleDrop('All Days');
+            setSelectedLocation({ locationName: 'All Locations', locationId: "all" });
+          }}
+        >
+          <Text
+            style={{
+              alignSelf: 'flex-start',
+              marginLeft: 16,
+              marginBottom: 8,
+              color: Theme.colors.gray5,
+              textDecorationLine: 'underline',
+              fontFamily: Theme.fonts.fontFamilyRegular,
+            }}
+          >
+            Clear All
+        </Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+};
+export default HomeChurchControls;

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -14,6 +14,66 @@ import { MainStackParamList } from '../../navigation/AppNavigator';
 import { LocationData } from '../../contexts/LocationContext';
 import { Theme, Style } from '../../Theme.style';
 
+const style = StyleSheet.create({
+  locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
+  container: {
+    backgroundColor: '#111111',
+    margin: 16,
+    width: Dimensions.get('window').width - 32,
+    position: 'relative',
+  },
+  containerItem: {
+    flexDirection: 'row',
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    paddingHorizontal: 20,
+    color: 'white',
+    minHeight: 56,
+    borderWidth: 1,
+    borderColor: '#1A1A1A',
+  },
+  locationSelectText: {
+    alignSelf: 'center',
+    flex: 1,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    color: '#fff',
+    fontSize: 16,
+  },
+  daySelectText: {
+    flex: 1,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    color: 'white',
+    padding: 16,
+  },
+  dropdownItemText: {
+    flex: 1,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    color: 'white',
+    padding: 16,
+  },
+  dropdownContainer: {
+    backgroundColor: '#111111',
+    top: 56,
+    width: '100%',
+    position: 'absolute',
+    zIndex: 1000,
+  },
+  clearText: {
+    alignSelf: 'flex-start',
+    marginLeft: 16,
+    marginBottom: 8,
+    color: Theme.colors.gray5,
+    textDecorationLine: 'underline',
+    fontFamily: Theme.fonts.fontFamilyRegular,
+  },
+  caretIcon: {
+    ...Style.icon,
+    alignSelf: 'center',
+  },
+  upsideDown: {
+    transform: [{ rotate: '180deg' }],
+  },
+});
+
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
   loc: LocationData;
@@ -43,103 +103,59 @@ const HomeChurchControls = ({
     'Sunday',
   ];
   const [active, setActive] = useState(false);
-  const style = StyleSheet.create({
-    locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
-    container: {
-      backgroundColor: '#111111',
-      margin: 16,
-      width: Dimensions.get('window').width - 32,
-      position: 'relative',
-    },
-    containerItem: {
-      flexDirection: 'row',
-      fontFamily: Theme.fonts.fontFamilyRegular,
-      paddingHorizontal: 20,
-      color: 'white',
-      minHeight: 56,
-      fontSize: 16,
-      borderWidth: 1,
-      borderColor: '#1A1A1A',
-    },
-    locationSelect: {
-      alignSelf: 'center',
-      flex: 1,
-      fontFamily: Theme.fonts.fontFamilyRegular,
-      color: '#fff',
-      fontSize: 16,
-    },
-  });
+
   const handleDrop = (day: string) => {
     setWeekDay(day);
     setDay(day);
     setActive(false);
   };
+
+  const handleClearButton = () => {
+    handleDrop('All Days');
+    setSelectedLocation({
+      locationName: 'All Locations',
+      locationId: 'all',
+    });
+  };
+
   useEffect(() => {
     setSelectedLocation(loc);
   }, [loc]);
+
   return (
     <>
       <View style={style.container}>
         <TouchableWithoutFeedback
           disabled={isLoading}
           onPress={() => navigation.push('HomeChurchLocationSelect', {})}
-          style={style.containerItem}
         >
-          <View
-            style={{
-              flexDirection: 'row',
-              height: 56,
-              marginLeft: 16,
-            }}
-          >
+          <View style={style.containerItem}>
             <Thumbnail
               style={style.locationIcon}
               source={Theme.icons.white.location}
               square
             />
-            <Text style={style.locationSelect}>
+            <Text style={style.locationSelectText}>
               {selectedLocation?.locationName}
             </Text>
           </View>
         </TouchableWithoutFeedback>
         <TouchableHighlight
           onBlur={() => setActive(false)}
-          style={style.containerItem}
           disabled={isLoading}
           onPress={() => setActive(!active)}
         >
-          <>
-            <Text
-              style={{
-                flex: 1,
-                fontFamily: Theme.fonts.fontFamilyRegular,
-                color: 'white',
-                padding: 16,
-              }}
-            >
-              {weekday}
-            </Text>
+          <View style={style.containerItem}>
+            <Text style={style.daySelectText}>{weekday}</Text>
             <Thumbnail
               source={Theme.icons.white.caretDown}
-              style={{
-                width: 24,
-                height: 24,
-                alignSelf: 'center',
-              }}
+              style={style.caretIcon}
             />
-          </>
+          </View>
         </TouchableHighlight>
 
         {active ? (
-          <View
-            style={{
-              backgroundColor: '#111111',
-              top: 56,
-              width: '100%',
-              position: 'absolute',
-              zIndex: 1000,
-            }}
-          >
+          <View style={style.dropdownContainer}>
             {days.map((day, index) => (
               <TouchableHighlight
                 key={day}
@@ -147,25 +163,11 @@ const HomeChurchControls = ({
                 style={style.containerItem}
               >
                 <>
-                  <Text
-                    style={{
-                      flex: 1,
-                      fontFamily: Theme.fonts.fontFamilyRegular,
-                      color: 'white',
-                      padding: 16,
-                    }}
-                  >
-                    {day}
-                  </Text>
+                  <Text style={style.dropdownItemText}>{day}</Text>
                   {index === 0 ? (
                     <Thumbnail
                       source={Theme.icons.white.caretDown}
-                      style={{
-                        transform: [{ rotate: '180deg' }],
-                        width: 24,
-                        height: 24,
-                        alignSelf: 'center',
-                      }}
+                      style={[style.caretIcon, style.upsideDown]}
                     />
                   ) : null}
                 </>
@@ -177,26 +179,9 @@ const HomeChurchControls = ({
       <TouchableOpacity
         disabled={active || isLoading}
         style={{ zIndex: -1, width: 100 }}
-        onPress={() => {
-          handleDrop('All Days');
-          setSelectedLocation({
-            locationName: 'All Locations',
-            locationId: 'all',
-          });
-        }}
+        onPress={handleClearButton}
       >
-        <Text
-          style={{
-            alignSelf: 'flex-start',
-            marginLeft: 16,
-            marginBottom: 8,
-            color: Theme.colors.gray5,
-            textDecorationLine: 'underline',
-            fontFamily: Theme.fonts.fontFamilyRegular,
-          }}
-        >
-          Clear All
-        </Text>
+        <Text style={style.clearText}>Clear All</Text>
       </TouchableOpacity>
     </>
   );

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -18,11 +18,13 @@ interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
   loc: LocationData;
   setDay: (day: string) => void;
+  isLoading: boolean;
 }
 const HomeChurchControls = ({
   loc,
   navigation,
   setDay,
+  isLoading,
 }: Params): JSX.Element => {
   const [selectedLocation, setSelectedLocation] = useState<LocationData>(
     loc?.locationName === 'unknown' || !loc?.locationName
@@ -79,6 +81,7 @@ const HomeChurchControls = ({
     <>
       <View style={style.container}>
         <TouchableWithoutFeedback
+          disabled={isLoading}
           onPress={() => navigation.push('HomeChurchLocationSelect', {})}
           style={style.containerItem}
         >
@@ -102,6 +105,7 @@ const HomeChurchControls = ({
         <TouchableHighlight
           onBlur={() => setActive(false)}
           style={style.containerItem}
+          disabled={isLoading}
           onPress={() => setActive(!active)}
         >
           <>
@@ -171,8 +175,8 @@ const HomeChurchControls = ({
         ) : null}
       </View>
       <TouchableOpacity
-        disabled={active}
-        style={{ zIndex: -1 }}
+        disabled={active || isLoading}
+        style={{ zIndex: -1, width: 100 }}
         onPress={() => {
           handleDrop('All Days');
           setSelectedLocation({

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -127,7 +127,7 @@ const HomeChurchControls = ({
       <View style={style.container}>
         <TouchableWithoutFeedback
           disabled={isLoading}
-          onPress={() => navigation.push('HomeChurchLocationSelect', {})}
+          onPress={() => navigation.navigate('HomeChurchLocationSelect', {})}
         >
           <View style={style.containerItem}>
             <Thumbnail

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -104,7 +104,26 @@ const HomeChurchControls = ({
           style={style.containerItem}
           onPress={() => setActive(!active)}
         >
-          <Text style={{ color: 'white', padding: 16 }}>{weekday}</Text>
+          <>
+            <Text
+              style={{
+                flex: 1,
+                fontFamily: Theme.fonts.fontFamilyRegular,
+                color: 'white',
+                padding: 16,
+              }}
+            >
+              {weekday}
+            </Text>
+            <Thumbnail
+              source={Theme.icons.white.caretDown}
+              style={{
+                width: 24,
+                height: 24,
+                alignSelf: 'center',
+              }}
+            />
+          </>
         </TouchableHighlight>
 
         {active ? (
@@ -117,13 +136,35 @@ const HomeChurchControls = ({
               zIndex: 1000,
             }}
           >
-            {days.map((day) => (
+            {days.map((day, index) => (
               <TouchableHighlight
                 key={day}
                 onPress={() => handleDrop(day)}
                 style={style.containerItem}
               >
-                <Text style={{ color: 'white', padding: 16 }}>{day}</Text>
+                <>
+                  <Text
+                    style={{
+                      flex: 1,
+                      fontFamily: Theme.fonts.fontFamilyRegular,
+                      color: 'white',
+                      padding: 16,
+                    }}
+                  >
+                    {day}
+                  </Text>
+                  {index === 0 ? (
+                    <Thumbnail
+                      source={Theme.icons.white.caretDown}
+                      style={{
+                        transform: [{ rotate: '180deg' }],
+                        width: 24,
+                        height: 24,
+                        alignSelf: 'center',
+                      }}
+                    />
+                  ) : null}
+                </>
               </TouchableHighlight>
             ))}
           </View>

--- a/src/screens/homechurch/HomeChurchControls.tsx
+++ b/src/screens/homechurch/HomeChurchControls.tsx
@@ -9,19 +9,25 @@ import {
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { TouchableHighlight } from 'react-native-gesture-handler';
 import { MainStackParamList } from '../../navigation/AppNavigator';
 import { LocationData } from '../../contexts/LocationContext';
 import { Theme, Style } from '../../Theme.style';
-import { TouchableHighlight } from 'react-native-gesture-handler';
 
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
   loc: LocationData;
   setDay: (day: string) => void;
 }
-const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element => {
+const HomeChurchControls = ({
+  loc,
+  navigation,
+  setDay,
+}: Params): JSX.Element => {
   const [selectedLocation, setSelectedLocation] = useState<LocationData>(
-    loc?.locationName === 'unknown' || !!!loc?.locationName ? { locationName: 'All Locations', locationId: "" } : { locationName: loc?.locationName, locationId: loc?.locationId }
+    loc?.locationName === 'unknown' || !loc?.locationName
+      ? { locationName: 'All Locations', locationId: '' }
+      : { locationName: loc?.locationName, locationId: loc?.locationId }
   );
   const [weekday, setWeekDay] = useState('All Days');
   const days = [
@@ -41,7 +47,7 @@ const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element =>
       backgroundColor: '#111111',
       margin: 16,
       width: Dimensions.get('window').width - 32,
-      position: 'relative'
+      position: 'relative',
     },
     containerItem: {
       flexDirection: 'row',
@@ -64,18 +70,16 @@ const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element =>
   const handleDrop = (day: string) => {
     setWeekDay(day);
     setDay(day);
-    setActive(false)
-  }
+    setActive(false);
+  };
   useEffect(() => {
-    setSelectedLocation(loc)
-  }, [loc])
+    setSelectedLocation(loc);
+  }, [loc]);
   return (
     <>
       <View style={style.container}>
         <TouchableWithoutFeedback
-          onPress={() =>
-            navigation.push('HomeChurchLocationSelect', {})
-          }
+          onPress={() => navigation.push('HomeChurchLocationSelect', {})}
           style={style.containerItem}
         >
           <View
@@ -90,10 +94,16 @@ const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element =>
               source={Theme.icons.white.location}
               square
             />
-            <Text style={style.locationSelect}>{selectedLocation?.locationName}</Text>
+            <Text style={style.locationSelect}>
+              {selectedLocation?.locationName}
+            </Text>
           </View>
         </TouchableWithoutFeedback>
-        <TouchableHighlight onBlur={() => setActive(false)} style={style.containerItem} onPress={() => setActive(!active)}>
+        <TouchableHighlight
+          onBlur={() => setActive(false)}
+          style={style.containerItem}
+          onPress={() => setActive(!active)}
+        >
           <Text style={{ color: 'white', padding: 16 }}>{weekday}</Text>
         </TouchableHighlight>
 
@@ -102,43 +112,47 @@ const HomeChurchControls = ({ loc, navigation, setDay }: Params): JSX.Element =>
             style={{
               backgroundColor: '#111111',
               top: 56,
-              width: "100%",
+              width: '100%',
               position: 'absolute',
               zIndex: 1000,
             }}
           >
             {days.map((day) => (
-              <TouchableHighlight key={day} onPress={() => handleDrop(day)} style={style.containerItem}>
+              <TouchableHighlight
+                key={day}
+                onPress={() => handleDrop(day)}
+                style={style.containerItem}
+              >
                 <Text style={{ color: 'white', padding: 16 }}>{day}</Text>
               </TouchableHighlight>
             ))}
           </View>
         ) : null}
-
       </View>
-      <View style={{ zIndex: -100 }}>
-
-        <TouchableOpacity
-          style={{ zIndex: -100, backgroundColor: "grey", width: 100 }}
-          onPress={() => {
-            handleDrop('All Days');
-            setSelectedLocation({ locationName: 'All Locations', locationId: "all" });
+      <TouchableOpacity
+        disabled={active}
+        style={{ zIndex: -1 }}
+        onPress={() => {
+          handleDrop('All Days');
+          setSelectedLocation({
+            locationName: 'All Locations',
+            locationId: 'all',
+          });
+        }}
+      >
+        <Text
+          style={{
+            alignSelf: 'flex-start',
+            marginLeft: 16,
+            marginBottom: 8,
+            color: Theme.colors.gray5,
+            textDecorationLine: 'underline',
+            fontFamily: Theme.fonts.fontFamilyRegular,
           }}
         >
-          <Text
-            style={{
-              alignSelf: 'flex-start',
-              marginLeft: 16,
-              marginBottom: 8,
-              color: Theme.colors.gray5,
-              textDecorationLine: 'underline',
-              fontFamily: Theme.fonts.fontFamilyRegular,
-            }}
-          >
-            Clear All
+          Clear All
         </Text>
-        </TouchableOpacity>
-      </View>
+      </TouchableOpacity>
     </>
   );
 };

--- a/src/screens/homechurch/HomeChurchExtendedModal.tsx
+++ b/src/screens/homechurch/HomeChurchExtendedModal.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import { Animated, Dimensions } from 'react-native';
+import {
+  PanGestureHandler,
+  PanGestureHandlerStateChangeEvent,
+} from 'react-native-gesture-handler';
+import HomeChurchItem from './HomeChurchItem';
+import { HomeChurch } from './HomeChurchScreen';
+
+const { height } = Dimensions.get('window');
+
+interface Params {
+  selected: HomeChurch;
+  setShowModal: (a: boolean) => void;
+}
+
+export default function HomeChurchExtendedModal({
+  selected,
+  setShowModal,
+}: Params): JSX.Element {
+  const translateY = new Animated.Value(height * 0.4);
+  const handleGesture = Animated.event(
+    [{ nativeEvent: { translationY: translateY } }],
+    { useNativeDriver: true }
+  );
+
+  function handleGestureEnd(e: PanGestureHandlerStateChangeEvent) {
+    if (e.nativeEvent.translationY > 60) {
+      Animated.timing(translateY, {
+        duration: 150,
+        useNativeDriver: true,
+        toValue: height * 0.4,
+      }).start();
+      setTimeout(() => setShowModal(false), 200);
+    } else {
+      Animated.timing(translateY, {
+        duration: 150,
+        useNativeDriver: true,
+        toValue: 0,
+      }).start();
+    }
+  }
+
+  useEffect(() => {
+    Animated.timing(translateY, {
+      duration: 150,
+      useNativeDriver: true,
+      toValue: 0,
+    }).start();
+  });
+
+  return (
+    <PanGestureHandler
+      onGestureEvent={handleGesture}
+      onHandlerStateChange={(e) => handleGestureEnd(e)}
+    >
+      <Animated.View
+        style={{
+          bottom: 0,
+          position: 'absolute',
+          zIndex: 200,
+          transform: [
+            {
+              translateY: translateY.interpolate({
+                inputRange: [0, height * 0.4],
+                outputRange: [0, height * 0.4],
+                extrapolate: 'clamp',
+              }),
+            },
+          ],
+        }}
+      >
+        <HomeChurchItem modal item={selected} />
+      </Animated.View>
+    </PanGestureHandler>
+  );
+}

--- a/src/screens/homechurch/HomeChurchExtendedModal.tsx
+++ b/src/screens/homechurch/HomeChurchExtendedModal.tsx
@@ -12,11 +12,13 @@ const { height } = Dimensions.get('window');
 interface Params {
   selected: HomeChurch;
   setShowModal: (a: boolean) => void;
+  locationToGroupType: (a: string) => string;
 }
 
 export default function HomeChurchExtendedModal({
   selected,
   setShowModal,
+  locationToGroupType,
 }: Params): JSX.Element {
   const translateY = new Animated.Value(height * 0.4);
   const handleGesture = Animated.event(
@@ -70,7 +72,11 @@ export default function HomeChurchExtendedModal({
           ],
         }}
       >
-        <HomeChurchItem modal item={selected} />
+        <HomeChurchItem
+          locationToGroupType={locationToGroupType}
+          item={selected}
+          modal
+        />
       </Animated.View>
     </PanGestureHandler>
   );

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import moment from 'moment';
+import {
+  View,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  Dimensions,
+} from 'react-native';
+import { Thumbnail } from 'native-base';
+import { Theme } from '../../Theme.style';
+import { HomeChurch } from './HomeChurchScreen';
+
+const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
+  const style = StyleSheet.create({
+    homeChurchCard: {
+      borderColor: '#1A1A1A',
+      borderWidth: 1,
+      backgroundColor: Theme.colors.gray1,
+      padding: 16,
+      width: Dimensions.get('window').width,
+    },
+    hmName: {
+      fontFamily: Theme.fonts.fontFamilyBold,
+      fontSize: 16,
+      lineHeight: 24,
+      color: 'white',
+    },
+    hmAddress: {
+      fontSize: 16,
+      lineHeight: 24,
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      fontWeight: '400',
+      color: Theme.colors.grey5,
+    },
+    hmDate: {
+      marginVertical: 8,
+      color: 'white',
+      fontFamily: Theme.fonts.fontFamilyBold,
+      fontSize: 12,
+      lineHeight: 18,
+    },
+    hmDescription: {
+      color: Theme.colors.grey5,
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      fontSize: 12,
+      lineHeight: 18,
+    },
+    badgesContainer: {
+      marginTop: 24,
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+    },
+    locationBadge: {
+      backgroundColor: Theme.colors.grey3,
+      borderRadius: 50,
+      paddingHorizontal: 12,
+      marginHorizontal: 2,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingVertical: 4,
+    },
+    locationBadgeText: {
+      color: 'white',
+      fontSize: 12,
+      lineHeight: 18,
+
+      fontFamily: Theme.fonts.fontFamilyRegular,
+    },
+  });
+  const getDayOfWeek = (homechurch: any) => {
+    // TODO: Fix
+    if (homechurch?.recurrences?.recurrence?.recurrenceWeekly)
+      if (item.recurrences.recurrence.recurrenceWeekly.occurOnSunday)
+        return 'Sunday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnMonday)
+        return 'Monday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnTuesday)
+        return 'Tuesday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnWednesday)
+        return 'Wednesday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnThursday)
+        return 'Thursday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnFriday)
+        return 'Friday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnSaturday)
+        return 'Saturday';
+      else return moment(item.startDate).format('dddd');
+    else return moment(item?.startDate).format('dddd');
+  };
+  return (
+    <View style={style.homeChurchCard}>
+      <View style={{ flexDirection: 'row' }}>
+        <View style={{ flex: 1 }}>
+          <Text style={style.hmName}>{item.name}</Text>
+          <Text style={style.hmAddress}>{item.location.address.address1}</Text>
+          <Text style={style.hmDate}>
+            {getDayOfWeek(item)}s{'\n'}
+            {moment(item.schedule?.startTime).format('h:mm a')}
+          </Text>
+        </View>
+        <View>
+          <TouchableOpacity
+            style={{
+              width: 40,
+              height: 40,
+              margin: 4,
+              marginRight: 16,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Thumbnail
+              square
+              source={Theme.icons.white.calendarAdd}
+              style={{
+                width: 24,
+                height: 24,
+              }}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={{
+              width: 40,
+              height: 40,
+              margin: 4,
+              marginRight: 16,
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Thumbnail
+              square
+              source={Theme.icons.white.contact}
+              style={{
+                width: 24,
+                height: 24,
+              }}
+            />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      <Text style={style.hmDescription}>{item.description}</Text>
+      <View style={style.badgesContainer}>
+        <View style={style.locationBadge}>
+          <Text style={style.locationBadgeText}>
+            {item.location.address.city}
+          </Text>
+        </View>
+        {item.name.includes('Family Friendly') && (
+          <View
+            style={[
+              style.locationBadge,
+              {
+                paddingHorizontal: 12,
+                backgroundColor: 'rgb(160, 226, 186)',
+              },
+            ]}
+          >
+            <Thumbnail // is this getting cropped?
+              square
+              source={Theme.icons.black.familyFriendly}
+              style={{ width: 16, height: 16 }}
+            />
+          </View>
+        )}
+      </View>
+    </View>
+  );
+};
+export default HomeChurchItem;

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -171,11 +171,10 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
       const createEntry = await Calendar.createEvent(
         {
           name: item?.name,
-          event: {
-            place: {
-              location: {
-                street: item?.location?.address?.address1,
-              },
+
+          place: {
+            location: {
+              street: item?.location?.address?.address1,
             },
           },
         },

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { Theme, Style } from '../../Theme.style';
-import { HomeChurch } from './HomeChurchScreen';
+import { HomeChurch, locationToGroupType } from './HomeChurchScreen';
 import HomeChurchConfirmationModal from './HomeChurchConfirmationModal';
 
 interface Params {
@@ -138,6 +138,7 @@ const HomeChurchItem = ({
       paddingVertical: 4,
     },
     locationBadgeText: {
+      textTransform: 'capitalize',
       color: 'white',
       fontSize: 12,
       lineHeight: 18,
@@ -248,17 +249,14 @@ const HomeChurchItem = ({
       item?.groupType?.id === '65432' ||
       item?.name?.includes('Family Friendly') ? (
         <View style={style.badgesContainer}>
-          {(item?.location?.address?.city &&
-            item?.location?.address?.city !== '') ||
-          (item?.location?.name && item?.groupType?.id !== '65432') ? (
-            <View style={style.locationBadge}>
-              <Text style={style.locationBadgeText}>
-                {item?.location?.address?.city === ''
-                  ? item?.location?.name
-                  : item?.location?.address?.city}
-              </Text>
-            </View>
-          ) : null}
+          <View style={style.locationBadge}>
+            <Text style={style.locationBadgeText}>
+              {locationToGroupType(item?.groupType?.id ?? '')?.replace(
+                '-',
+                ' '
+              )}
+            </Text>
+          </View>
           {item?.name?.includes('Family Friendly') && (
             <View
               style={[
@@ -276,11 +274,6 @@ const HomeChurchItem = ({
               />
             </View>
           )}
-          {item?.groupType?.id === '65432' ? (
-            <View style={style.locationBadge}>
-              <Text style={style.locationBadgeText}>Global</Text>
-            </View>
-          ) : null}
         </View>
       ) : null}
     </View>

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -8,7 +8,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { Thumbnail } from 'native-base';
-import { Theme } from '../../Theme.style';
+import { Theme, Style } from '../../Theme.style';
 import { HomeChurch } from './HomeChurchScreen';
 import HomeChurchConfirmationModal from './HomeChurchConfirmationModal';
 
@@ -22,7 +22,6 @@ interface Params {
 const { width, height } = Dimensions.get('window');
 
 export const getDayOfWeek = (homechurch: HomeChurch): string => {
-  // TODO: Fix
   if (homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly)
     if (
       homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
@@ -98,7 +97,6 @@ const HomeChurchItem = ({
           width,
           minHeight: modal ? height * 0.4 : 0,
         },
-
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
       fontSize: card ? 15 : 16,
@@ -152,25 +150,30 @@ const HomeChurchItem = ({
       justifyContent: 'center',
       alignItems: 'center',
     },
+    drawerIndicator: {
+      marginTop: -8,
+      marginBottom: 8,
+      borderRadius: 100,
+      width: 40,
+      alignSelf: 'center',
+      height: 5,
+      backgroundColor: Theme.colors.white,
+    },
+    openDrawerModalText: {
+      color: 'white',
+      fontSize: 12,
+      lineHeight: 18,
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      textDecorationLine: 'underline',
+    },
   });
 
   const [confirmationModal, setConfirmationModal] = useState(false);
   const [type, setType] = useState<'contact' | 'calendar' | ''>('');
+
   return (
     <View style={style.homeChurchCard}>
-      {modal ? (
-        <View
-          style={{
-            marginTop: -8,
-            marginBottom: 8,
-            borderRadius: 100,
-            width: 40,
-            alignSelf: 'center',
-            height: 5,
-            backgroundColor: Theme.colors.white,
-          }}
-        />
-      ) : null}
+      {modal ? <View style={style.drawerIndicator} /> : null}
       {confirmationModal ? (
         <HomeChurchConfirmationModal
           type={type}
@@ -206,10 +209,7 @@ const HomeChurchItem = ({
             <Thumbnail
               square
               source={Theme.icons.white.calendarAdd}
-              style={{
-                width: 24,
-                height: 24,
-              }}
+              style={Style.icon}
             />
           </TouchableOpacity>
           <TouchableOpacity
@@ -222,10 +222,7 @@ const HomeChurchItem = ({
             <Thumbnail
               square
               source={Theme.icons.white.contact}
-              style={{
-                width: 24,
-                height: 24,
-              }}
+              style={Style.icon}
             />
           </TouchableOpacity>
         </View>
@@ -243,17 +240,7 @@ const HomeChurchItem = ({
             if (openModal) openModal();
           }}
         >
-          <Text
-            style={{
-              color: 'white',
-              fontSize: 12,
-              lineHeight: 18,
-              fontFamily: Theme.fonts.fontFamilyRegular,
-              textDecorationLine: 'underline',
-            }}
-          >
-            See More
-          </Text>
+          <Text style={style.openDrawerModalText}>See More</Text>
         </TouchableOpacity>
       ) : null}
       {item?.location?.address?.city ||

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -276,6 +276,16 @@ const HomeChurchItem = ({
           )}
         </View>
       ) : null}
+      {!card && !modal ? (
+        <View
+          style={{
+            marginTop: 15,
+            borderBottomColor: 'rgba(191, 191, 191, 0.1)',
+            borderBottomWidth: 2,
+            width: '110%',
+          }}
+        />
+      ) : null}
     </View>
   );
 };

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { Theme, Style } from '../../Theme.style';
-import { HomeChurch, locationToGroupType } from './HomeChurchScreen';
+import { HomeChurch } from './HomeChurchScreen';
 import HomeChurchConfirmationModal from './HomeChurchConfirmationModal';
 
 interface Params {
@@ -18,6 +18,7 @@ interface Params {
   modal?: boolean;
   active?: boolean;
   openModal?: () => void;
+  locationToGroupType: (a: string) => string;
 }
 const { width, height } = Dimensions.get('window');
 
@@ -68,6 +69,7 @@ const HomeChurchItem = ({
   card,
   modal,
   openModal,
+  locationToGroupType,
 }: Params): JSX.Element => {
   const style = StyleSheet.create({
     homeChurchCard: card
@@ -89,13 +91,13 @@ const HomeChurchItem = ({
           backgroundColor: '#1a1a1a',
           padding: 16,
           width,
-          minHeight: modal ? height * 0.4 : 0,
+          minHeight: height * 0.4,
         }
       : {
           backgroundColor: '#1a1a1a',
           padding: 16,
           width,
-          minHeight: modal ? height * 0.4 : 0,
+          paddingBottom: 0,
         },
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
@@ -171,7 +173,6 @@ const HomeChurchItem = ({
 
   const [confirmationModal, setConfirmationModal] = useState(false);
   const [type, setType] = useState<'contact' | 'calendar' | ''>('');
-
   return (
     <View style={style.homeChurchCard}>
       {modal ? <View style={style.drawerIndicator} /> : null}

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -20,6 +20,49 @@ interface Params {
   active?: boolean;
 }
 const { width, height } = Dimensions.get('window');
+
+export const getDayOfWeek = (homechurch: HomeChurch) => {
+  // TODO: Fix
+  if (homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly)
+    if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnSunday
+    )
+      return 'Sunday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnMonday
+    )
+      return 'Monday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnTuesday
+    )
+      return 'Tuesday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnWednesday
+    )
+      return 'Wednesday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnThursday
+    )
+      return 'Thursday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnFriday
+    )
+      return 'Friday';
+    else if (
+      homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+        ?.occurOnSaturday
+    )
+      return 'Saturday';
+    else return moment(homechurch.startDate).format('dddd');
+  else return moment(homechurch?.startDate).format('dddd');
+};
+
 const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
   const style = StyleSheet.create({
     homeChurchCard: card
@@ -97,47 +140,6 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
       alignItems: 'center',
     },
   });
-  const getDayOfWeek = (homechurch: HomeChurch) => {
-    // TODO: Fix
-    if (homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly)
-      if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnSunday
-      )
-        return 'Sunday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnMonday
-      )
-        return 'Monday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnTuesday
-      )
-        return 'Tuesday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnWednesday
-      )
-        return 'Wednesday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnThursday
-      )
-        return 'Thursday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnFriday
-      )
-        return 'Friday';
-      else if (
-        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
-          ?.occurOnSaturday
-      )
-        return 'Saturday';
-      else return moment(homechurch.startDate).format('dddd');
-    else return moment(homechurch?.startDate).format('dddd');
-  };
 
   const addToCalendar = async () => {
     let startTime;
@@ -202,7 +204,8 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
             </Text>
           ) : null}
           <Text style={style.hmDate}>
-            {getDayOfWeek(item)}s{'\n'}
+            {getDayOfWeek(item)}
+            {'\n'}
             {moment(item?.schedule?.startTime).format('h:mm a')}
           </Text>
         </View>

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -32,7 +32,7 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
           padding: 16,
           borderTopWidth: 2,
           borderTopColor: active ? '#FFF' : 'transparent',
-          width: modal ? width : width - 80,
+          width: width - 80,
           overflow: 'hidden',
           flexWrap: 'nowrap',
         }

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -11,15 +11,32 @@ import { Thumbnail } from 'native-base';
 import { Theme } from '../../Theme.style';
 import { HomeChurch } from './HomeChurchScreen';
 
-const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
+interface Params {
+  item: HomeChurch;
+  card?: boolean;
+}
+const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
   const style = StyleSheet.create({
-    homeChurchCard: {
-      borderColor: '#1A1A1A',
-      borderWidth: 1,
-      backgroundColor: Theme.colors.gray1,
-      padding: 16,
-      width: Dimensions.get('window').width,
-    },
+    homeChurchCard: card
+      ? {
+          margin: 16,
+          borderColor: '#1A1A1A',
+          borderWidth: 1,
+          backgroundColor: Theme.colors.gray1,
+          padding: 16,
+          borderTopWidth: 2,
+          borderTopColor: '#FFF',
+          width: Dimensions.get('window').width - 32,
+          overflow: 'scroll',
+          flex: 1,
+        }
+      : {
+          borderColor: '#1A1A1A',
+          borderWidth: 1,
+          backgroundColor: Theme.colors.gray1,
+          padding: 16,
+          width: Dimensions.get('window').width,
+        },
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
       fontSize: 16,
@@ -68,35 +85,58 @@ const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
       fontFamily: Theme.fonts.fontFamilyRegular,
     },
   });
-  const getDayOfWeek = (homechurch: any) => {
+  const getDayOfWeek = (homechurch: HomeChurch) => {
     // TODO: Fix
-    if (homechurch?.recurrences?.recurrence?.recurrenceWeekly)
-      if (item.recurrences.recurrence.recurrenceWeekly.occurOnSunday)
+    if (homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly)
+      if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnSunday
+      )
         return 'Sunday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnMonday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnMonday
+      )
         return 'Monday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnTuesday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnTuesday
+      )
         return 'Tuesday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnWednesday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnWednesday
+      )
         return 'Wednesday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnThursday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnThursday
+      )
         return 'Thursday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnFriday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnFriday
+      )
         return 'Friday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnSaturday)
+      else if (
+        homechurch?.schedule?.recurrences?.recurrence?.recurrenceWeekly
+          ?.occurOnSaturday
+      )
         return 'Saturday';
-      else return moment(item.startDate).format('dddd');
-    else return moment(item?.startDate).format('dddd');
+      else return moment(homechurch.startDate).format('dddd');
+    else return moment(homechurch?.startDate).format('dddd');
   };
   return (
     <View style={style.homeChurchCard}>
       <View style={{ flexDirection: 'row' }}>
         <View style={{ flex: 1 }}>
-          <Text style={style.hmName}>{item.name}</Text>
-          <Text style={style.hmAddress}>{item.location.address.address1}</Text>
+          <Text style={style.hmName}>{item?.name}</Text>
+          <Text style={style.hmAddress}>
+            {item?.location?.address?.address1}
+          </Text>
           <Text style={style.hmDate}>
             {getDayOfWeek(item)}s{'\n'}
-            {moment(item.schedule?.startTime).format('h:mm a')}
+            {moment(item?.schedule?.startTime).format('h:mm a')}
           </Text>
         </View>
         <View>
@@ -141,14 +181,14 @@ const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
         </View>
       </View>
 
-      <Text style={style.hmDescription}>{item.description}</Text>
+      <Text style={style.hmDescription}>{item?.description}</Text>
       <View style={style.badgesContainer}>
         <View style={style.locationBadge}>
           <Text style={style.locationBadgeText}>
-            {item.location.address.city}
+            {item?.location?.address?.city}
           </Text>
         </View>
-        {item.name.includes('Family Friendly') && (
+        {item?.name?.includes('Family Friendly') && (
           <View
             style={[
               style.locationBadge,

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -74,8 +74,6 @@ const HomeChurchItem = ({
   const style = StyleSheet.create({
     homeChurchCard: card
       ? {
-          // TODO: FIX Card height
-          // TODO: Description needs to show ellipsis with "See More"
           backgroundColor: '#1A1A1A',
           padding: 16,
           borderTopWidth: 2,
@@ -84,17 +82,24 @@ const HomeChurchItem = ({
           overflow: 'hidden',
           flexWrap: 'nowrap',
         }
-      : {
+      : modal
+      ? {
           borderTopWidth: 2,
-          borderRadius: 2,
+          borderRadius: 4,
           borderColor: 'grey',
-
           shadowColor: '#ddd',
           backgroundColor: '#1a1a1a',
           padding: 16,
           width,
           minHeight: modal ? height * 0.4 : 0,
+        }
+      : {
+          backgroundColor: '#1a1a1a',
+          padding: 16,
+          width,
+          minHeight: modal ? height * 0.4 : 0,
         },
+
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
       fontSize: card ? 15 : 16,
@@ -210,7 +215,7 @@ const HomeChurchItem = ({
       ) : null}
       <View style={{ flexDirection: 'row' }}>
         <View style={{ flex: 1 }}>
-          <Text numberOfLines={modal ? 2 : 1} style={style.hmName}>
+          <Text numberOfLines={modal || !card ? 2 : 1} style={style.hmName}>
             {item?.name}
           </Text>
           {item?.location?.address?.address1 ? (
@@ -259,7 +264,7 @@ const HomeChurchItem = ({
       </View>
       <Text
         ellipsizeMode="tail"
-        numberOfLines={card ? 1 : 8}
+        numberOfLines={card ? 2 : 8}
         style={style.hmDescription}
       >
         {item?.description}

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -257,6 +257,7 @@ const HomeChurchItem = ({
         </TouchableOpacity>
       ) : null}
       {item?.location?.address?.city ||
+      item?.groupType?.id === '65432' ||
       item?.name?.includes('Family Friendly') ? (
         <View style={style.badgesContainer}>
           {item?.location?.address?.city ? (
@@ -283,6 +284,11 @@ const HomeChurchItem = ({
               />
             </View>
           )}
+          {item?.groupType?.id === '65432' ? (
+            <View style={style.locationBadge}>
+              <Text style={style.locationBadgeText}>Global</Text>
+            </View>
+          ) : null}
         </View>
       ) : null}
     </View>

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -23,12 +23,10 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
           borderColor: '#1A1A1A',
           borderWidth: 1,
           backgroundColor: Theme.colors.gray1,
-          marginRight: 16,
           padding: 16,
           borderTopWidth: 2,
           borderTopColor: '#FFF',
-          width: Dimensions.get('window').width * 0.8,
-          flex: 1,
+          width: Dimensions.get('window').width,
           flexWrap: 'nowrap',
         }
       : {
@@ -45,7 +43,7 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
       color: 'white',
     },
     hmAddress: {
-      fontSize: 16,
+      fontSize: card ? 12 : 16,
       lineHeight: 24,
       fontFamily: Theme.fonts.fontFamilyRegular,
       fontWeight: '400',
@@ -82,8 +80,14 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
       color: 'white',
       fontSize: 12,
       lineHeight: 18,
-
       fontFamily: Theme.fonts.fontFamilyRegular,
+    },
+    iconContainer: {
+      width: 40,
+      height: 40,
+      marginBottom: 8,
+      justifyContent: 'center',
+      alignItems: 'center',
     },
   });
   const getDayOfWeek = (homechurch: HomeChurch) => {
@@ -141,16 +145,7 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
           </Text>
         </View>
         <View>
-          <TouchableOpacity
-            style={{
-              width: 40,
-              height: 40,
-              margin: 4,
-              marginRight: 16,
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
+          <TouchableOpacity style={style.iconContainer}>
             <Thumbnail
               square
               source={Theme.icons.white.calendarAdd}
@@ -160,16 +155,7 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
               }}
             />
           </TouchableOpacity>
-          <TouchableOpacity
-            style={{
-              width: 40,
-              height: 40,
-              margin: 4,
-              marginRight: 16,
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
+          <TouchableOpacity style={style.iconContainer}>
             <Thumbnail
               square
               source={Theme.icons.white.contact}
@@ -201,7 +187,7 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
               },
             ]}
           >
-            <Thumbnail // is this getting cropped?
+            <Thumbnail
               square
               source={Theme.icons.black.familyFriendly}
               style={{ width: 16, height: 16 }}

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -18,6 +18,7 @@ interface Params {
   card?: boolean;
   modal?: boolean;
   active?: boolean;
+  openModal?: () => void;
 }
 const { width, height } = Dimensions.get('window');
 
@@ -63,7 +64,13 @@ export const getDayOfWeek = (homechurch: HomeChurch) => {
   else return moment(homechurch?.startDate).format('dddd');
 };
 
-const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
+const HomeChurchItem = ({
+  active,
+  item,
+  card,
+  modal,
+  openModal,
+}: Params): JSX.Element => {
   const style = StyleSheet.create({
     homeChurchCard: card
       ? {
@@ -78,7 +85,12 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
           flexWrap: 'nowrap',
         }
       : {
-          backgroundColor: '#1A1A1A',
+          borderTopWidth: 2,
+          borderRadius: 2,
+          borderColor: 'grey',
+
+          shadowColor: '#ddd',
+          backgroundColor: '#1a1a1a',
           padding: 16,
           width,
           minHeight: modal ? height * 0.4 : 0,
@@ -247,11 +259,30 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
       </View>
       <Text
         ellipsizeMode="tail"
-        numberOfLines={card ? 2 : 8}
+        numberOfLines={card ? 1 : 8}
         style={style.hmDescription}
       >
         {item?.description}
       </Text>
+      {card ? (
+        <TouchableOpacity
+          onPress={() => {
+            if (openModal) openModal();
+          }}
+        >
+          <Text
+            style={{
+              color: 'white',
+              fontSize: 12,
+              lineHeight: 18,
+              fontFamily: Theme.fonts.fontFamilyRegular,
+              textDecorationLine: 'underline',
+            }}
+          >
+            See More
+          </Text>
+        </TouchableOpacity>
+      ) : null}
       {item?.location?.address?.city ||
       item?.name?.includes('Family Friendly') ? (
         <View style={style.badgesContainer}>

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import moment from 'moment';
 import {
   View,
@@ -6,6 +6,7 @@ import {
   Text,
   TouchableOpacity,
   Dimensions,
+  Linking,
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { Theme } from '../../Theme.style';
@@ -14,19 +15,24 @@ import { HomeChurch } from './HomeChurchScreen';
 interface Params {
   item: HomeChurch;
   card?: boolean;
+  active?: boolean;
 }
-const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
+const { width, height } = Dimensions.get('window');
+const HomeChurchItem = ({ active, item, card }: Params): JSX.Element => {
+  const [modal, setModal] = useState(false);
   const style = StyleSheet.create({
     homeChurchCard: card
       ? {
           // TODO: FIX Card height, width
+          // TODO: description needs to show ellipsis with "See More"
           borderColor: '#1A1A1A',
           borderWidth: 1,
           backgroundColor: Theme.colors.gray1,
           padding: 16,
           borderTopWidth: 2,
-          borderTopColor: '#FFF',
-          width: Dimensions.get('window').width,
+          borderTopColor: active ? '#FFF' : 'transparent',
+          width: width - 80,
+          overflow: 'hidden',
           flexWrap: 'nowrap',
         }
       : {
@@ -34,11 +40,11 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
           borderWidth: 1,
           backgroundColor: Theme.colors.gray1,
           padding: 16,
-          width: Dimensions.get('window').width,
+          width,
         },
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
-      fontSize: 16,
+      fontSize: card ? 15 : 16,
       lineHeight: 24,
       color: 'white',
     },
@@ -65,7 +71,7 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
     badgesContainer: {
       marginTop: 24,
       flexDirection: 'row',
-      justifyContent: 'flex-start',
+      alignContent: 'center',
     },
     locationBadge: {
       backgroundColor: Theme.colors.grey3,
@@ -136,9 +142,11 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
       <View style={{ flexDirection: 'row' }}>
         <View style={{ flex: 1 }}>
           <Text style={style.hmName}>{item?.name}</Text>
-          <Text style={style.hmAddress}>
-            {item?.location?.address?.address1}
-          </Text>
+          {item?.location?.address?.address1 ? (
+            <Text style={style.hmAddress}>
+              {item?.location?.address?.address1}
+            </Text>
+          ) : null}
           <Text style={style.hmDate}>
             {getDayOfWeek(item)}s{'\n'}
             {moment(item?.schedule?.startTime).format('h:mm a')}
@@ -155,7 +163,10 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
               }}
             />
           </TouchableOpacity>
-          <TouchableOpacity style={style.iconContainer}>
+          <TouchableOpacity
+            onPress={() => Linking.openURL('mailto:')}
+            style={style.iconContainer}
+          >
             <Thumbnail
               square
               source={Theme.icons.white.contact}
@@ -168,33 +179,42 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
         </View>
       </View>
 
-      <Text ellipsizeMode="tail" numberOfLines={2} style={style.hmDescription}>
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={card ? 1 : 8}
+        style={style.hmDescription}
+      >
         {item?.description}
       </Text>
-      <View style={style.badgesContainer}>
-        <View style={style.locationBadge}>
-          <Text style={style.locationBadgeText}>
-            {item?.location?.address?.city}
-          </Text>
+      {item?.location?.address?.city ||
+      item?.name?.includes('Family Friendly') ? (
+        <View style={style.badgesContainer}>
+          {item?.location?.address?.city ? (
+            <View style={style.locationBadge}>
+              <Text style={style.locationBadgeText}>
+                {item?.location?.address?.city}
+              </Text>
+            </View>
+          ) : null}
+          {item?.name?.includes('Family Friendly') && (
+            <View
+              style={[
+                style.locationBadge,
+                {
+                  paddingHorizontal: 12,
+                  backgroundColor: 'rgb(160, 226, 186)',
+                },
+              ]}
+            >
+              <Thumbnail
+                square
+                source={Theme.icons.black.familyFriendly}
+                style={{ width: 16, height: 16 }}
+              />
+            </View>
+          )}
         </View>
-        {item?.name?.includes('Family Friendly') && (
-          <View
-            style={[
-              style.locationBadge,
-              {
-                paddingHorizontal: 12,
-                backgroundColor: 'rgb(160, 226, 186)',
-              },
-            ]}
-          >
-            <Thumbnail
-              square
-              source={Theme.icons.black.familyFriendly}
-              style={{ width: 16, height: 16 }}
-            />
-          </View>
-        )}
-      </View>
+      ) : null}
     </View>
   );
 };

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -19,16 +19,17 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
   const style = StyleSheet.create({
     homeChurchCard: card
       ? {
-          margin: 16,
+          // TODO: FIX Card height, width
           borderColor: '#1A1A1A',
           borderWidth: 1,
           backgroundColor: Theme.colors.gray1,
+          marginRight: 16,
           padding: 16,
           borderTopWidth: 2,
           borderTopColor: '#FFF',
-          width: Dimensions.get('window').width - 32,
-          overflow: 'scroll',
+          width: Dimensions.get('window').width * 0.8,
           flex: 1,
+          flexWrap: 'nowrap',
         }
       : {
           borderColor: '#1A1A1A',
@@ -181,7 +182,9 @@ const HomeChurchItem = ({ item, card }: Params): JSX.Element => {
         </View>
       </View>
 
-      <Text style={style.hmDescription}>{item?.description}</Text>
+      <Text ellipsizeMode="tail" numberOfLines={2} style={style.hmDescription}>
+        {item?.description}
+      </Text>
       <View style={style.badgesContainer}>
         <View style={style.locationBadge}>
           <Text style={style.locationBadgeText}>

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -192,7 +192,7 @@ const HomeChurchItem = ({
           <Text style={style.hmDate}>
             {getDayOfWeek(item)}
             {'\n'}
-            {moment(item?.schedule?.startTime).format('h:mm a')}
+            {moment(item?.schedule?.startTime).format('h:mm a')} EDT
           </Text>
         </View>
         <View>
@@ -257,13 +257,18 @@ const HomeChurchItem = ({
         </TouchableOpacity>
       ) : null}
       {item?.location?.address?.city ||
+      item?.location?.name ||
       item?.groupType?.id === '65432' ||
       item?.name?.includes('Family Friendly') ? (
         <View style={style.badgesContainer}>
-          {item?.location?.address?.city ? (
+          {(item?.location?.address?.city &&
+            item?.location?.address?.city !== '') ||
+          (item?.location?.name && item?.groupType?.id !== '65432') ? (
             <View style={style.locationBadge}>
               <Text style={style.locationBadgeText}>
-                {item?.location?.address?.city}
+                {item?.location?.address?.city === ''
+                  ? item?.location?.name
+                  : item?.location?.address?.city}
               </Text>
             </View>
           ) : null}

--- a/src/screens/homechurch/HomeChurchItem.tsx
+++ b/src/screens/homechurch/HomeChurchItem.tsx
@@ -67,11 +67,9 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
   const style = StyleSheet.create({
     homeChurchCard: card
       ? {
-          // TODO: FIX Card height, width
-          // TODO: description needs to show ellipsis with "See More"
-          borderColor: '#1A1A1A',
-          borderWidth: 1,
-          backgroundColor: Theme.colors.gray1,
+          // TODO: FIX Card height
+          // TODO: Description needs to show ellipsis with "See More"
+          backgroundColor: '#1A1A1A',
           padding: 16,
           borderTopWidth: 2,
           borderTopColor: active ? '#FFF' : 'transparent',
@@ -80,11 +78,10 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
           flexWrap: 'nowrap',
         }
       : {
-          borderColor: '#1A1A1A',
-          borderWidth: 1,
-          backgroundColor: Theme.colors.gray1,
+          backgroundColor: '#1A1A1A',
           padding: 16,
           width,
+          minHeight: modal ? height * 0.4 : 0,
         },
     hmName: {
       fontFamily: Theme.fonts.fontFamilyBold,
@@ -162,16 +159,10 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
         });
     }
     const endTime = moment(startTime).add(2, 'hours');
-    /* console.log(startTime.format('YYYY-MM-DD hh:mm:ss a'));
-    console.log(endTime.format('YYYY-MM-DD hh:mm:ss a'));
-    console.log(item?.name);
-    console.log(item?.location?.address?.address1);
- */
     try {
       const createEntry = await Calendar.createEvent(
         {
           name: item?.name,
-
           place: {
             location: {
               street: item?.location?.address?.address1,
@@ -192,9 +183,22 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
   };
   return (
     <View style={style.homeChurchCard}>
+      {modal ? (
+        <View
+          style={{
+            marginTop: -8,
+            marginBottom: 8,
+            borderRadius: 100,
+            width: 40,
+            alignSelf: 'center',
+            height: 5,
+            backgroundColor: Theme.colors.white,
+          }}
+        />
+      ) : null}
       <View style={{ flexDirection: 'row' }}>
         <View style={{ flex: 1 }}>
-          <Text numberOfLines={1} style={style.hmName}>
+          <Text numberOfLines={modal ? 2 : 1} style={style.hmName}>
             {item?.name}
           </Text>
           {item?.location?.address?.address1 ? (
@@ -243,7 +247,7 @@ const HomeChurchItem = ({ active, item, card, modal }: Params): JSX.Element => {
       </View>
       <Text
         ellipsizeMode="tail"
-        numberOfLines={card ? 1 : 8}
+        numberOfLines={card ? 2 : 8}
         style={style.hmDescription}
       >
         {item?.description}

--- a/src/screens/homechurch/HomeChurchLocationSelect.tsx
+++ b/src/screens/homechurch/HomeChurchLocationSelect.tsx
@@ -10,17 +10,17 @@ import {
 import { Thumbnail } from 'native-base';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
+import { LocationData } from 'src/contexts/LocationContext';
 import { Theme, Style } from '../../Theme.style';
 
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
-  loc: any;
+  loc: LocationData;
 }
-
+// TODO: Add missing type
+// TODO: white bottom border missing on postal code
 const HomeChurchLocationSelect = ({ loc, navigation }: Params): JSX.Element => {
-  const [selectedLocation, setSelectedLocation] = useState(
-    loc.locationData.locationName
-  );
+  const [selectedLocation, setSelectedLocation] = useState(loc?.locationName);
   const [postalCode, setPostalCode] = useState('');
   const style = StyleSheet.create({
     locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },

--- a/src/screens/homechurch/HomeChurchLocationSelect.tsx
+++ b/src/screens/homechurch/HomeChurchLocationSelect.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  TouchableWithoutFeedback,
+  TouchableOpacity,
+  View,
+  Text,
+  TextInput,
+} from 'react-native';
+import { Thumbnail } from 'native-base';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { MainStackParamList } from 'src/navigation/AppNavigator';
+import { Theme, Style } from '../../Theme.style';
+
+interface Params {
+  navigation: StackNavigationProp<MainStackParamList>;
+  loc: any;
+}
+
+const HomeChurchLocationSelect = ({ loc, navigation }: Params): JSX.Element => {
+  const [selectedLocation, setSelectedLocation] = useState(
+    loc.locationData.locationName
+  );
+  const [postalCode, setPostalCode] = useState('');
+  const style = StyleSheet.create({
+    locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
+    container: {
+      backgroundColor: '#111111',
+      margin: 16,
+    },
+    containerItem: {
+      flexDirection: 'row',
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      paddingHorizontal: 20,
+      color: 'white',
+      height: 56,
+      fontSize: 16,
+      borderWidth: 1,
+      borderColor: '#1A1A1A',
+    },
+    locationSelect: {
+      alignSelf: 'center',
+      flex: 1,
+      fontFamily: Theme.fonts.fontFamilyRegular,
+      color: '#fff',
+      fontSize: 16,
+    },
+  });
+  return (
+    <>
+      <View style={style.container}>
+        <TouchableWithoutFeedback
+          onPress={() =>
+            navigation.push('LocationSelectionScreen', { persist: true })
+          }
+          style={style.containerItem}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              flex: 1,
+              height: 56,
+              marginLeft: 16,
+            }}
+          >
+            <Thumbnail
+              style={style.locationIcon}
+              source={Theme.icons.white.location}
+              square
+            />
+            <Text style={style.locationSelect}>{selectedLocation}</Text>
+          </View>
+        </TouchableWithoutFeedback>
+
+        <TextInput
+          accessibilityLabel="Add Postal Code"
+          keyboardAppearance="dark"
+          placeholder="Add postal code"
+          placeholderTextColor="#646469"
+          textContentType="none"
+          keyboardType="default"
+          multiline
+          value={postalCode}
+          onChange={(text) => {
+            if (!text.nativeEvent.text.includes(' '))
+              setPostalCode(text.nativeEvent.text);
+          }}
+          textAlignVertical="center"
+          maxLength={6}
+          autoCapitalize="characters"
+          style={style.containerItem}
+        />
+      </View>
+      <TouchableOpacity
+        onPress={() => {
+          setPostalCode('');
+          setSelectedLocation('All Locations');
+        }}
+      >
+        <Text
+          style={{
+            alignSelf: 'flex-end',
+            marginRight: 16,
+            marginBottom: 8,
+            color: Theme.colors.gray5,
+            textDecorationLine: 'underline',
+            fontFamily: Theme.fonts.fontFamilyRegular,
+          }}
+        >
+          Clear All
+        </Text>
+      </TouchableOpacity>
+    </>
+  );
+};
+export default HomeChurchLocationSelect;

--- a/src/screens/homechurch/HomeChurchLocationSelect.tsx
+++ b/src/screens/homechurch/HomeChurchLocationSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext, useLayoutEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import {
   Container,
   Content,
@@ -16,7 +16,6 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as SecureStore from 'expo-secure-store';
-import { RouteProp } from '@react-navigation/native';
 import { LocationData } from '../../contexts/LocationContext';
 import LocationsService from '../../services/LocationsService';
 import Theme, { Style, HeaderStyle } from '../../Theme.style';
@@ -98,9 +97,11 @@ type Params = {
 export default function HomeChurchLocationSelect({
   navigation,
 }: Params): JSX.Element {
-
   const [locations, setLocations] = useState<LocationData[]>([]);
-  const [selectedLocation, setSelectedLocation] = useState({ locationName: "", locationId: "" });
+  const [selectedLocation, setSelectedLocation] = useState({
+    locationName: '',
+    locationId: '',
+  });
   const [searchText, setSearchText] = useState('');
   // eslint-disable-next-line camelcase
 
@@ -121,7 +122,9 @@ export default function HomeChurchLocationSelect({
       headerRight: function render() {
         return (
           <TouchableOpacity
-            onPress={() => navigation.navigate("HomeChurchScreen", { loc: selectedLocation })}
+            onPress={() =>
+              navigation.navigate('HomeChurchScreen', { loc: selectedLocation })
+            }
           >
             <Text style={style.headerButtonText}>Done</Text>
           </TouchableOpacity>
@@ -129,22 +132,26 @@ export default function HomeChurchLocationSelect({
       },
       headerRightContainerStyle: { right: 16 },
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLocation]);
   useEffect(() => {
     const loadLocations = () => {
       const locationsResult = LocationsService.loadLocationDataForContext();
-      setLocations(
-        [{ locationName: "All Locations", locationId: "all" }, ...locationsResult.sort((a, b) =>
+      setLocations([
+        { locationName: 'All Locations', locationId: 'all' },
+        { locationName: 'Global', locationId: 'global' },
+        ...locationsResult.sort((a, b) =>
           (a?.locationName as string).localeCompare(b?.locationName as string)
-        )]
-      );
+        ),
+      ]);
     };
     loadLocations();
     async function getLocation() {
-      const location = await SecureStore.getItemAsync('location')
-      setSelectedLocation({ ...selectedLocation, locationId: location ?? "" })
+      const location = await SecureStore.getItemAsync('location');
+      setSelectedLocation({ ...selectedLocation, locationId: location ?? '' });
     }
-    getLocation()
+    getLocation();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
     <Container style={{ backgroundColor: 'black' }}>
@@ -187,9 +194,7 @@ export default function HomeChurchLocationSelect({
                   <ListItem
                     key={item.locationId}
                     style={style.listItem}
-                    onPress={() =>
-                      setSelectedLocation(item)
-                    }
+                    onPress={() => setSelectedLocation(item)}
                   >
                     <Left>
                       <Text style={style.listText}>{item.locationName}</Text>

--- a/src/screens/homechurch/HomeChurchLocationSelect.tsx
+++ b/src/screens/homechurch/HomeChurchLocationSelect.tsx
@@ -99,8 +99,8 @@ const HomeChurchLocationSelect = ({ loc, navigation }: Params): JSX.Element => {
       >
         <Text
           style={{
-            alignSelf: 'flex-end',
-            marginRight: 16,
+            alignSelf: 'flex-start',
+            marginLeft: 16,
             marginBottom: 8,
             color: Theme.colors.gray5,
             textDecorationLine: 'underline',

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
   },
   map: {
     width,
-    height: height * 0.7,
+    height: height < 758 ? height * 0.63 : height * 0.66,
   },
   list: {
     backgroundColor: '#000',
@@ -69,7 +69,7 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
         },
         pitch: 1,
         heading: 1,
-        zoom: 12,
+        zoom: 11,
         altitude: 30000,
       },
       { duration: 400 }
@@ -92,19 +92,6 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
     }
     const location = await Location.getCurrentPositionAsync({});
     setUserLocation(location?.coords);
-    mapRef?.current?.animateCamera(
-      {
-        center: {
-          latitude: location?.coords?.latitude ?? '43.4675',
-          longitude: location?.coords?.longitude ?? '-79.6877',
-        },
-        pitch: 1,
-        heading: 1,
-        zoom: 12,
-        altitude: 30000,
-      },
-      { duration: 3 }
-    );
   };
 
   const Modal = (): JSX.Element => {
@@ -121,7 +108,7 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
           useNativeDriver: true,
           toValue: height * 0.4,
         }).start();
-        setTimeout(() => setShowModal(false), 500);
+        setTimeout(() => setShowModal(false), 300);
       } else {
         Animated.timing(translateY, {
           duration: 150,
@@ -169,9 +156,24 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
         rotateEnabled={false}
         pitchEnabled={false}
         zoomControlEnabled
-        mapPadding={{ top: 16, left: 16, right: 16, bottom: 16 }}
+        zoomEnabled
+        initialCamera={{
+          center: {
+            latitude: parseFloat(
+              homeChurches[0]?.location?.address?.latitude ?? '43.4675'
+            ),
+            longitude: parseFloat(
+              homeChurches[0]?.location?.address?.longitude ?? '-79.6877'
+            ),
+          },
+          pitch: 1,
+          heading: 1,
+          zoom: 11,
+          altitude: 30000,
+        }}
         onMapReady={async () => getUserLocation()}
         showsUserLocation
+        showsCompass={false}
         loadingEnabled
         ref={mapRef}
         style={styles.map}

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -17,7 +17,7 @@ import * as Location from 'expo-location';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Theme } from '../../Theme.style';
 import HomeChurchItem from './HomeChurchItem';
-import { HomeChurchData } from './HomeChurchScreen';
+import { HomeChurchData, locationToGroupType } from './HomeChurchScreen';
 import HomeChurchExtendedModal from './HomeChurchExtendedModal';
 
 const { width, height } = Dimensions.get('window');
@@ -191,6 +191,7 @@ export default function HomeChurchMapScreen({
 
       {showModal ? (
         <HomeChurchExtendedModal
+          locationToGroupType={locationToGroupType}
           setShowModal={() => {
             setShowModal(!showModal);
           }}
@@ -221,6 +222,7 @@ export default function HomeChurchMapScreen({
         data={homeChurches}
         renderItem={({ item, index }) => (
           <HomeChurchItem
+            locationToGroupType={locationToGroupType}
             openModal={() => {
               setSelected(index);
               setShowModal(true);

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -5,8 +5,6 @@ import {
   View,
   Dimensions,
   FlatList,
-  Animated,
-  ScrollResponderEvent,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
@@ -14,11 +12,6 @@ import { Thumbnail } from 'native-base';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
 import { RouteProp } from '@react-navigation/native';
 import * as Location from 'expo-location';
-import {
-  PanGestureHandler,
-  PanGestureHandlerStateChangeEvent,
-  TouchableOpacity,
-} from 'react-native-gesture-handler';
 import { Theme } from '../../Theme.style';
 import HomeChurchItem from './HomeChurchItem';
 import { HomeChurch, HomeChurchData } from './HomeChurchScreen';
@@ -36,7 +29,6 @@ const styles = StyleSheet.create({
     height: height * 0.7,
   },
   list: {
-    height: height * 0.4,
     backgroundColor: '#000',
     width,
   },
@@ -45,6 +37,7 @@ interface Params {
   route: RouteProp<MainStackParamList, 'HomeChurchMapScreen'>;
 }
 export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
+  const cardLength = width - 80 + 16;
   const homeChurches: HomeChurchData = route?.params?.items;
   const [userLocation, setUserLocation] = useState<
     Location.LocationObject['coords']
@@ -53,25 +46,24 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
   const mapRef = useRef<MapView>(null);
   const [selected, setSelected] = useState(0);
   const handleListScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    // console.log(event.nativeEvent)
     const xOffset = event.nativeEvent.contentOffset.x;
-    setSelected(Math.round(xOffset / 296));
+    setSelected(Math.round(xOffset / cardLength));
     mapRef?.current?.animateCamera(
       {
         center: {
           latitude: parseFloat(
-            homeChurches[Math.round(xOffset / 296)]?.location?.address
+            homeChurches[Math.round(xOffset / cardLength)]?.location?.address
               ?.latitude ?? '43.4675'
           ),
           longitude: parseFloat(
-            homeChurches[Math.round(xOffset / 296)]?.location?.address
+            homeChurches[Math.round(xOffset / cardLength)]?.location?.address
               ?.longitude ?? '-79.6877'
           ),
         },
         pitch: 1,
         heading: 1,
         zoom: 12,
-        altitude: 3,
+        altitude: 30000,
       },
       { duration: 400 }
     );
@@ -101,7 +93,7 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
         pitch: 1,
         heading: 1,
         zoom: 12,
-        altitude: 3,
+        altitude: 30000,
       },
       { duration: 3 }
     );
@@ -174,7 +166,7 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
         ItemSeparatorComponent={() => <View style={{ width: 16 }} />}
         contentContainerStyle={{ padding: 16 }}
         getItemLayout={(data, index) => {
-          return { length: 296, offset: 296 * index - 24, index };
+          return { length: cardLength, offset: cardLength * index - 24, index };
         }}
         style={styles.list}
         /* 

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -241,9 +241,15 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
         */
         data={homeChurches}
         renderItem={({ item, index }) => (
-          <TouchableOpacity onPress={() => setShowModal(!showModal)}>
-            <HomeChurchItem active={index === selected} card item={item} />
-          </TouchableOpacity>
+          <HomeChurchItem
+            openModal={() => {
+              setSelected(index);
+              setShowModal(true);
+            }}
+            active={index === selected}
+            card
+            item={item}
+          />
         )}
         horizontal
       />

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, SyntheticEvent } from 'react';
 import MapView, { Marker } from 'react-native-maps';
-import { StyleSheet, View, Dimensions, FlatList, Animated } from 'react-native';
+import { StyleSheet, View, Dimensions, FlatList, Animated, ScrollResponderEvent, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
 import { RouteProp } from '@react-navigation/native';
@@ -46,19 +46,21 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
   const [selected, setSelected] = useState(0);
   useEffect(() => {
     if (listRef && listRef?.current) {
-      // TODO: this is not working right now
       const cardWidth = width - 64;
       const a = cardWidth * selected;
       listRef.current.scrollToOffset({
         animated: true,
-        offset: a -24
+        offset: a - 24
       });
     }
+    console.log("=========================================")
+    console.log(homeChurches[selected]?.location?.address?.latitude)
+    console.log(homeChurches[selected]?.location?.address?.longitude)
     mapRef?.current?.animateCamera(
       {
         center: {
           latitude: parseFloat(homeChurches[selected]?.location?.address?.latitude ?? "43.4675" ) ,
-          longitude:parseFloat(homeChurches[selected]?.location?.address?.longitude ?? "-79.6877") ,
+          longitude: parseFloat(homeChurches[selected]?.location?.address?.longitude ?? "-79.6877") ,
         },
         pitch: 1,
         heading: 1,
@@ -67,15 +69,12 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
       },
       { duration: 400 }
     );
-
   }, [selected]);
-  const handleScroll = (e) => {
-    console.log(e.nativeEvent)
-    let xOffset = e.nativeEvent.contentOffset.x
-    let contentWidth = e.nativeEvent.contentSize.width
-/*  console.log(`Home Church Qty: ${homeChurches.length}`)
-    console.log(`xOffset: ${Math.round(xOffset/296)}`) //this number needs be relative to display
-    console.log(`contentWidth: ${contentWidth}`) */
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    // console.log(event.nativeEvent)
+    let xOffset = event.nativeEvent.contentOffset.x
+    let contentWidth = event.nativeEvent.contentSize.width
+    // This number needs be relative to display
     setSelected(Math.round(xOffset/296))
   }
   const getUserLocation = async () => {
@@ -88,8 +87,8 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
     mapRef?.current?.animateCamera(
       {
         center: {
-          latitude: location?.coords?.latitude ?? 43.4675,
-          longitude: location?.coords?.longitude ?? -79.6877,
+          latitude: location?.coords?.latitude ?? "43.4675",
+          longitude: location?.coords?.longitude ?? "-79.6877",
         },
         pitch: 1,
         heading: 1,
@@ -102,6 +101,9 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
   return (
     <View style={styles.container}>
       <MapView
+        rotateEnabled={false}
+        pitchEnabled={false}
+        zoomControlEnabled
         mapPadding={{ top: 16, left: 16, right: 16, bottom: 16 }}
         onMapReady={async () => getUserLocation()}
         showsUserLocation
@@ -111,11 +113,6 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
       >
         {homeChurches?.length
           ? homeChurches
-              .filter(
-                (church) =>
-                  church?.location?.address?.latitude &&
-                  church?.location?.address?.longitude
-              )
               .map((church, index) => {
                 return (
                   <Marker
@@ -177,11 +174,7 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
           The data fed to the flatlist needs to match data fed to markers. Indexes must match 
           Online Home Churches will not show up on map screen (?) 
         */
-        data={homeChurches.filter( // is this filter needed?
-          (church) =>
-            church?.location?.address?.latitude &&
-            church?.location?.address?.longitude
-        )}
+        data={homeChurches}
         renderItem={({ item, index }) => (
             <HomeChurchItem active={index === selected} card item={item} />
         )}

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import MapView, { Marker } from 'react-native-maps';
+import { StyleSheet, View, Dimensions, FlatList, Text } from 'react-native';
+import { Thumbnail } from 'native-base';
+import { Theme } from '../../Theme.style';
+import HomeChurchItem from './HomeChurchItem';
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  map: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').height / 1.5,
+  },
+});
+
+export default function HomeChurchMapScreen({ route }): JSX.Element {
+  const homeChurches = route?.params.items;
+  const [selected, setSelected] = useState();
+  return (
+    <View style={styles.container}>
+      <MapView
+        initialRegion={{
+          latitude: 43.4675,
+          longitude: -79.6877,
+          latitudeDelta: 0.122,
+          longitudeDelta: 0.1521,
+        }}
+        style={styles.map}
+      >
+        {homeChurches?.length
+          ? homeChurches
+              .filter(
+                (church) =>
+                  church.location.address.latitude &&
+                  church.location.address.longitude
+              )
+              .map((church) => {
+                return (
+                  <Marker
+                    onPress={() => setSelected(church.id)}
+                    key={church.id}
+                    style={{ zIndex: 10000 }}
+                    coordinate={{
+                      latitude: parseFloat(church.location.address.latitude),
+                      longitude: parseFloat(church.location.address.longitude),
+                    }}
+                  >
+                    <View
+                      style={{
+                        marginLeft: 16,
+                        marginTop: 30,
+                        padding: 12,
+                        backgroundColor: 'black',
+                        borderRadius: 50,
+                      }}
+                    >
+                      <Thumbnail
+                        square
+                        style={{ width: 18, height: 18 }}
+                        source={Theme.icons.white.homeChurch}
+                      />
+                    </View>
+                  </Marker>
+                );
+              })
+          : null}
+      </MapView>
+      <FlatList
+        pagingEnabled
+        style={{ backgroundColor: '#000' }}
+        ItemSeparatorComponent={() => <View style={{ borderColor: 'white' }} />}
+        data={homeChurches}
+        renderItem={({ item }) => <HomeChurchItem item={item} />}
+        horizontal
+      />
+    </View>
+  );
+}

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -18,6 +18,7 @@ import {
   PanGestureHandler,
   PanGestureHandlerStateChangeEvent,
 } from 'react-native-gesture-handler';
+import { StackNavigationProp } from '@react-navigation/stack';
 import { Theme } from '../../Theme.style';
 import HomeChurchItem from './HomeChurchItem';
 import { HomeChurch, HomeChurchData } from './HomeChurchScreen';
@@ -41,8 +42,12 @@ const styles = StyleSheet.create({
 });
 interface Params {
   route: RouteProp<MainStackParamList, 'HomeChurchMapScreen'>;
+  navigation: StackNavigationProp<MainStackParamList>;
 }
-export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
+export default function HomeChurchMapScreen({
+  route,
+  navigation,
+}: Params): JSX.Element {
   const cardLength = width - 80 + 16;
   const homeChurches: HomeChurchData = route?.params?.items;
   const [userLocation, setUserLocation] = useState<
@@ -152,6 +157,26 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
   };
   return (
     <View style={styles.container}>
+      <TouchableOpacity
+        onPress={() => navigation.goBack()}
+        style={{
+          zIndex: 20000,
+          position: 'absolute',
+          borderRadius: 50,
+          top: 52,
+          right: 24,
+          padding: 8,
+          backgroundColor: 'rgba(0,0,0,.7)',
+        }}
+      >
+        <Thumbnail
+          style={{
+            width: 26,
+            height: 26,
+          }}
+          source={Theme.icons.white.closeCancel}
+        />
+      </TouchableOpacity>
       <MapView
         rotateEnabled={false}
         pitchEnabled={false}

--- a/src/screens/homechurch/HomeChurchMapScreen.tsx
+++ b/src/screens/homechurch/HomeChurchMapScreen.tsx
@@ -16,7 +16,12 @@ const styles = StyleSheet.create({
   },
   map: {
     width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height / 1.5,
+    height: Dimensions.get('window').height * 0.7, // TODO: Increase map size
+  },
+  list: {
+    height: Dimensions.get('window').height * 0.3,
+    backgroundColor: '#000',
+    padding: 16,
   },
 });
 interface Params {
@@ -25,11 +30,15 @@ interface Params {
 
 export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
   const homeChurches: HomeChurchData = route?.params?.items;
-  const listRef = useRef(null);
+  const listRef = useRef<any>(null); // TODO: fix type
   const [selected, setSelected] = useState(0);
   useEffect(() => {
     if (listRef && listRef?.current) {
-      listRef?.current?.scrollToIndex({ animated: true, index: selected });
+      listRef.current.scrollToIndex({
+        animated: true,
+        index: selected,
+        viewOffset: Dimensions.get('window').width * 0.8, // TODO: fix offset
+      });
     }
   }, [selected]);
   return (
@@ -55,7 +64,6 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
                   <Marker
                     onPress={() => setSelected(index)}
                     key={church?.id}
-                    style={{ zIndex: 10000 }}
                     coordinate={{
                       latitude: parseFloat(
                         church?.location?.address?.latitude ?? '43.6532'
@@ -67,17 +75,20 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
                   >
                     <View
                       style={{
-                        marginLeft: 16,
-                        marginTop: 30,
                         padding: 12,
-                        backgroundColor: 'black',
+                        backgroundColor: selected === index ? 'black' : 'white',
                         borderRadius: 50,
+                        borderWidth: 2,
                       }}
                     >
                       <Thumbnail
                         square
                         style={{ width: 18, height: 18 }}
-                        source={Theme.icons.white.homeChurch}
+                        source={
+                          selected === index
+                            ? Theme.icons.white.homeChurch
+                            : Theme.icons.black.homeChurch
+                        }
                       />
                     </View>
                   </Marker>
@@ -88,9 +99,10 @@ export default function HomeChurchMapScreen({ route }: Params): JSX.Element {
       <FlatList
         pagingEnabled
         ref={listRef}
-        style={{ backgroundColor: '#000' }}
+        style={styles.list}
         getItemLayout={(data, index) => ({
-          length: Dimensions.get('window').width,
+          // TODO: FIX OFFSET
+          length: Dimensions.get('window').width * 0.8,
           offset: Dimensions.get('window').width * index,
           index,
         })} /* The data fed to the flatlist needs to match data fed to markers. Indexes must match */

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -5,10 +5,12 @@ import {
   Text,
   FlatList,
   ActivityIndicator,
+  TouchableOpacity,
+  Dimensions,
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { ScrollView } from 'react-native-gesture-handler';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
 import API, { GraphQLResult } from '@aws-amplify/api';
 import { ListF1ListGroup2sQuery } from 'src/services/API';
@@ -144,7 +146,6 @@ export default function HomeChurchScreen({
             limit: 200,
           },
         })) as GraphQLResult<ListF1ListGroup2sQuery>;
-        // setHomeChurches(json.data?.listF1ListGroup2s?.items ?? []);
         setHomeChurches(json.data?.listF1ListGroup2s?.items ?? []);
       } catch (err) {
         console.log(err);
@@ -184,15 +185,63 @@ export default function HomeChurchScreen({
           />
         </View>
       ) : null}
-      <View style={{ marginBottom: 10 }}>
-        <HomeChurchControls
-          setDay={setDay}
-          navigation={navigation}
-          loc={location}
-        />
-        <View style={{ flexDirection: 'row', zIndex: -2 }}>
-          <Text style={style.resultsCount}>{`${
-            homeChurches.filter((a) => {
+      <ScrollView>
+        <View style={{ marginBottom: 10 }}>
+          <HomeChurchControls
+            setDay={setDay}
+            navigation={navigation}
+            loc={location}
+          />
+          <View style={{ flexDirection: 'row', zIndex: -2 }}>
+            <Text style={style.resultsCount}>{`${
+              homeChurches.filter((a) => {
+                return (
+                  (location?.locationId === 'all' && getDayOfWeek(a) === day) ||
+                  (location?.locationId === 'all' && day === 'All Days') ||
+                  (locationToGroupType(a?.groupType?.id ?? '') ===
+                    location?.locationId &&
+                    getDayOfWeek(a) === day) ||
+                  (locationToGroupType(a?.groupType?.id ?? '') ===
+                    location?.locationId &&
+                    day === 'All Days')
+                );
+              }).length
+            } Results`}</Text>
+            <IconButton
+              labelStyle={{
+                color: 'black',
+                fontFamily: Theme.fonts.fontFamilyBold,
+              }}
+              icon={Theme.icons.black.map}
+              label="Map"
+              style={{
+                alignSelf: 'flex-end',
+                paddingLeft: 12,
+                height: 50,
+                marginRight: 16,
+                width: 100,
+                backgroundColor: '#fff',
+              }}
+              onPress={() =>
+                navigation.navigate('HomeChurchMapScreen', {
+                  items: homeChurches.filter(
+                    (church) =>
+                      church?.location?.address?.latitude !== '' &&
+                      church?.location?.address?.longitude !== ''
+                  ),
+                })
+              }
+            />
+          </View>
+        </View>
+        <View
+          style={{
+            zIndex: -200,
+            minHeight: Dimensions.get('window').height / 2,
+          }}
+        >
+          {homeChurches
+            .filter((a) => {
               return (
                 (location?.locationId === 'all' && getDayOfWeek(a) === day) ||
                 (location?.locationId === 'all' && day === 'All Days') ||
@@ -203,54 +252,12 @@ export default function HomeChurchScreen({
                   location?.locationId &&
                   day === 'All Days')
               );
-            }).length
-          } Results`}</Text>
-          <IconButton
-            labelStyle={{
-              color: 'black',
-              fontFamily: Theme.fonts.fontFamilyBold,
-            }}
-            icon={Theme.icons.black.map}
-            label="Map"
-            style={{
-              alignSelf: 'flex-end',
-              paddingLeft: 12,
-              height: 50,
-              marginRight: 16,
-              width: 100,
-              backgroundColor: '#fff',
-            }}
-            onPress={() =>
-              navigation.navigate('HomeChurchMapScreen', {
-                items: homeChurches.filter(
-                  (church) =>
-                    church?.location?.address?.latitude &&
-                    church.location.address.longitude
-                ),
-              })
-            }
-          />
+            })
+            .map((a) => {
+              return <HomeChurchItem key={a?.id} item={a} />;
+            })}
         </View>
-      </View>
-      <FlatList
-        style={{ zIndex: -1 }}
-        data={homeChurches.filter((a) => {
-          return (
-            (location?.locationId === 'all' && getDayOfWeek(a) === day) ||
-            (location?.locationId === 'all' && day === 'All Days') ||
-            (locationToGroupType(a?.groupType?.id ?? '') ===
-              location?.locationId &&
-              getDayOfWeek(a) === day) ||
-            (locationToGroupType(a?.groupType?.id ?? '') ===
-              location?.locationId &&
-              day === 'All Days')
-          );
-        })}
-        renderItem={({ item }) => <HomeChurchItem item={item} />}
-        keyExtractor={(item, index) => {
-          return item?.id ?? index.toString();
-        }}
-      />
+      </ScrollView>
     </View>
   );
 }

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -36,6 +36,8 @@ export const locationToGroupType = (groupId: string) => {
       return 'hamilton-downtown';
     case '58250':
       return 'hamilton-mountain';
+    case '58251':
+      return 'hamilton-ancaster';
     case '58253':
       return 'kitchener';
     case '58254':
@@ -66,6 +68,7 @@ export const locationToGroupType = (groupId: string) => {
       return 'waterloo';
     case '65432':
       return 'global';
+
     default:
       return 'Unknown';
   }
@@ -271,7 +274,13 @@ export default function HomeChurchScreen({
               );
             })
             .map((a) => {
-              return <HomeChurchItem key={a?.id} item={a} />;
+              return (
+                <HomeChurchItem
+                  locationToGroupType={locationToGroupType}
+                  key={a?.id}
+                  item={a}
+                />
+              );
             })}
         </View>
         {location?.locationId === 'all' &&

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -248,6 +248,7 @@ export default function HomeChurchScreen({
         </View>
         <View
           style={{
+            backgroundColor: '#1a1a1a',
             zIndex: -200,
             minHeight: Dimensions.get('window').height / 2,
           }}
@@ -272,7 +273,18 @@ export default function HomeChurchScreen({
               );
             })
             .map((a) => {
-              return <HomeChurchItem key={a?.id} item={a} />;
+              return (
+                <React.Fragment key={a?.id}>
+                  <HomeChurchItem item={a} />
+                  <View
+                    style={{
+                      borderBottomColor: 'rgba(191, 191, 191, 0.1)',
+                      marginLeft: 16,
+                      borderBottomWidth: 1,
+                    }}
+                  />
+                </React.Fragment>
+              );
             })}
         </View>
         {location?.locationId === 'all' &&

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -138,6 +138,8 @@ export default function HomeChurchScreen({
         return 'toronto-uptown';
       case '57909':
         return 'waterloo';
+      case '65432':
+        return 'global';
       default:
         return 'Unknown';
     }

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -251,6 +251,7 @@ export default function HomeChurchScreen({
         </View>
         <View
           style={{
+            zIndex: -1,
             minHeight: Dimensions.get('window').height / 2,
           }}
         >

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -27,12 +27,12 @@ const style = StyleSheet.create({
   header: Style.header,
   headerTitle: HeaderStyle.title,
   resultsCount: {
+    flex: 1,
+    alignSelf: 'flex-end',
     fontFamily: Theme.fonts.fontFamilyBold,
     fontSize: 16,
-    lineHeight: 18,
     color: Theme.colors.grey5,
     marginHorizontal: 16,
-    marginVertical: 8,
   },
 });
 
@@ -113,7 +113,7 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
             limit: 200,
           },
         })) as GraphQLResult<ListF1ListGroup2sQuery>;
-        setHomeChurches(json.data?.listF1ListGroup2s?.items ?? []);
+        // setHomeChurches(json.data?.listF1ListGroup2s?.items ?? []);
         setHomeChurches(
           json.data?.listF1ListGroup2s?.items?.filter(
             (church) => church?.groupType?.id === '58082'
@@ -169,29 +169,32 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
                   : location?.locationData
               }
             />
-            <Text
-              style={style.resultsCount}
-            >{`${homeChurches.length} Results`}</Text>
-            <IconButton
-              labelStyle={{
-                color: 'black',
-                fontFamily: Theme.fonts.fontFamilyBold,
-              }}
-              icon={Theme.icons.black.map}
-              label="Map"
-              style={{
-                marginLeft: 12,
-                paddingLeft: 8,
-                height: 50,
-                width: 100,
-                backgroundColor: '#fff',
-              }}
-              onPress={() =>
-                navigation.navigate('HomeChurchMapScreen', {
-                  items: homeChurches,
-                })
-              }
-            />
+            <View style={{ flexDirection: 'row' }}>
+              <Text
+                style={style.resultsCount}
+              >{`${homeChurches.length} Results`}</Text>
+              <IconButton
+                labelStyle={{
+                  color: 'black',
+                  fontFamily: Theme.fonts.fontFamilyBold,
+                }}
+                icon={Theme.icons.black.map}
+                label="Map"
+                style={{
+                  alignSelf: 'flex-end',
+                  paddingLeft: 12,
+                  height: 50,
+                  marginRight: 16,
+                  width: 100,
+                  backgroundColor: '#fff',
+                }}
+                onPress={() =>
+                  navigation.navigate('HomeChurchMapScreen', {
+                    items: homeChurches,
+                  })
+                }
+              />
+            </View>
           </View>
         }
       />

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -248,8 +248,6 @@ export default function HomeChurchScreen({
         </View>
         <View
           style={{
-            backgroundColor: '#1a1a1a',
-            zIndex: -200,
             minHeight: Dimensions.get('window').height / 2,
           }}
         >
@@ -273,18 +271,7 @@ export default function HomeChurchScreen({
               );
             })
             .map((a) => {
-              return (
-                <React.Fragment key={a?.id}>
-                  <HomeChurchItem item={a} />
-                  <View
-                    style={{
-                      borderBottomColor: 'rgba(191, 191, 191, 0.1)',
-                      marginLeft: 16,
-                      borderBottomWidth: 1,
-                    }}
-                  />
-                </React.Fragment>
-              );
+              return <HomeChurchItem key={a?.id} item={a} />;
             })}
         </View>
         {location?.locationId === 'all' &&

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -17,6 +17,7 @@ import { Theme, Style, HeaderStyle } from '../../Theme.style';
 import LocationContext from '../../contexts/LocationContext';
 import HomeChurchItem from './HomeChurchItem';
 import HomeChurchLocationSelect from './HomeChurchLocationSelect';
+import IconButton from '../../components/buttons/IconButton';
 
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
@@ -35,7 +36,7 @@ const style = StyleSheet.create({
   },
 });
 
-type HomeChurchData = NonNullable<
+export type HomeChurchData = NonNullable<
   NonNullable<NonNullable<ListF1ListGroup2sQuery>['listF1ListGroup2s']>['items']
 >;
 export type HomeChurch = HomeChurchData[0];
@@ -89,12 +90,13 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
             limit: 500,
           },
         })) as GraphQLResult<ListF1ListGroup2sQuery>;
-        setHomeChurches(json?.data?.listF1ListGroup2s?.items ?? []);
-        /*          json?.data?.listF1ListGroup2s?.items?.filter(
+        setHomeChurches(
+          json?.data?.listF1ListGroup2s?.items?.filter(
             (a) =>
               a?.location?.address?.city ===
                 location?.locationData?.locationName ?? 'Oakville'
-          ) ?? [] */
+          ) ?? []
+        );
       } catch (err) {
         console.log(err);
       } finally {
@@ -110,7 +112,7 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
       {isLoading ? (
         <View
           style={{
-            // TODO: fix this
+            // TODO: fix this centering
             flex: 1,
             justifyContent: 'center',
             position: 'absolute',
@@ -137,22 +139,33 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
         }}
         ListHeaderComponent={
           <View>
-            <HomeChurchLocationSelect navigation={navigation} loc={location} />
+            <HomeChurchLocationSelect
+              navigation={navigation}
+              loc={location?.locationData}
+            />
             <Text
               style={style.resultsCount}
             >{`${homeChurches.length} Results`}</Text>
+            <IconButton
+              labelStyle={{
+                color: 'black',
+                fontFamily: Theme.fonts.fontFamilyBold,
+              }}
+              icon={Theme.icons.black.map}
+              label="Map"
+              style={{
+                marginLeft: 12,
+                height: 50,
+                width: 100,
+                backgroundColor: '#fff',
+              }}
+              onPress={() =>
+                navigation.navigate('HomeChurchMapScreen', {
+                  items: homeChurches,
+                })
+              }
+            />
           </View>
-        }
-        ListFooterComponent={
-          <TouchableOpacity
-            onPress={() => {
-              navigation.navigate('HomeChurchMapScreen', {
-                items: homeChurches,
-              });
-            }}
-          >
-            <Text style={{ color: 'white' }}>GO TO MAP</Text>
-          </TouchableOpacity>
         }
       />
     </View>

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -51,7 +51,12 @@ export default function HomeChurchScreen({
   loc,
 }: Params): JSX.Element {
   const [location, setLocation] = useState(
-    useContext(LocationContext)?.locationData
+    useContext(LocationContext)?.locationData?.locationId === 'unknown'
+      ? {
+          locationName: 'All Locations',
+          locationId: 'all',
+        }
+      : useContext(LocationContext)?.locationData
   );
   const [isLoading, setIsLoading] = useState(true);
   const [day, setDay] = useState('All Days');

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -22,6 +22,55 @@ import IconButton from '../../components/buttons/IconButton';
 import HomeChurchControls from './HomeChurchControls';
 import AllButton from '../../../src/components/buttons/AllButton';
 
+export const locationToGroupType = (groupId: string) => {
+  switch (groupId) {
+    case '62948':
+      return 'alliston';
+    case '58224':
+      return 'brampton';
+    case '58225':
+      return 'brantford';
+    case '58248':
+      return 'burlington';
+    case '58249':
+      return 'hamilton-downtown';
+    case '58250':
+      return 'hamilton-mountain';
+    case '58253':
+      return 'kitchener';
+    case '58254':
+      return 'london';
+    case '58069':
+      return 'newmarket';
+    case '58082':
+      return 'oakville';
+    case '58255':
+      return 'ottawa';
+    case '58252':
+      return 'owen-sound';
+    case '58256':
+      return 'parry-sound';
+    case '58081':
+      return 'richmond-hill';
+    case '62947':
+      return 'sandbanks';
+    case '58083':
+      return 'toronto-downtown';
+    case '58258':
+      return 'toronto-east';
+    case '58257':
+      return 'toronto-high-park';
+    case '58259':
+      return 'toronto-uptown';
+    case '57909':
+      return 'waterloo';
+    case '65432':
+      return 'global';
+    default:
+      return 'Unknown';
+  }
+};
+
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
   route: RouteProp<MainStackParamList, 'HomeChurchScreen'>;
@@ -95,55 +144,6 @@ export default function HomeChurchScreen({
   }, [navigation]);
 
   const [homeChurches, setHomeChurches] = useState<HomeChurchData>([]);
-
-  const locationToGroupType = (groupId: string) => {
-    switch (groupId) {
-      case '62948':
-        return 'alliston';
-      case '58224':
-        return 'brampton';
-      case '58225':
-        return 'brantford';
-      case '58248':
-        return 'burlington';
-      case '58249':
-        return 'hamilton-downtown';
-      case '58250':
-        return 'hamilton-mountain';
-      case '58253':
-        return 'kitchener';
-      case '58254':
-        return 'london';
-      case '58069':
-        return 'newmarket';
-      case '58082':
-        return 'oakville';
-      case '58255':
-        return 'ottawa';
-      case '58252':
-        return 'owen-sound';
-      case '58256':
-        return 'parry-sound';
-      case '58081':
-        return 'richmond-hill';
-      case '62947':
-        return 'sandbanks';
-      case '58083':
-        return 'toronto-downtown';
-      case '58258':
-        return 'toronto-east';
-      case '58257':
-        return 'toronto-high-park';
-      case '58259':
-        return 'toronto-uptown';
-      case '57909':
-        return 'waterloo';
-      case '65432':
-        return 'global';
-      default:
-        return 'Unknown';
-    }
-  };
 
   useEffect(() => {
     const loadHomeChurches = async () => {

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -78,23 +78,45 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
   }, [navigation]);
 
   const [homeChurches, setHomeChurches] = useState<HomeChurchData>([]);
+
+  /*     
+  const maps = {
+      alliston: '62948',
+      ancaster: '58251',
+      brampton: '58224',
+      brantford: '58225',
+      burlington: '58248',
+      'hamilton-downtown': '58249',
+      'hamilton-mountain': '58250',
+      kitchener: '58253',
+      london: '58254',
+      newmarket: '58069',
+      oakville: '58082',
+      ottawa: '58255',
+      'owen-sound': '58252',
+      'parry-sound': '58256',
+      'richmond-hill': '58081',
+      sandbanks: '62947',
+      'toronto-downtown': '58083',
+      'toronto-east': '58258',
+      'toronto-high-park': '58257',
+      'toronto-uptown': '58259',
+      waterloo: '57909',
+    }; */
+
   useEffect(() => {
-    /*
-      TODO: Not all locations are showing. City names not matching?
-    */
     const loadHomeChurches = async () => {
       try {
         const json = (await API.graphql({
           query: listF1ListGroup2s,
           variables: {
-            limit: 500,
+            limit: 200,
           },
         })) as GraphQLResult<ListF1ListGroup2sQuery>;
+        setHomeChurches(json.data?.listF1ListGroup2s?.items ?? []);
         setHomeChurches(
-          json?.data?.listF1ListGroup2s?.items?.filter(
-            (a) =>
-              a?.location?.address?.city ===
-                location?.locationData?.locationName ?? 'Oakville'
+          json.data?.listF1ListGroup2s?.items?.filter(
+            (church) => church?.groupType?.id === '58082'
           ) ?? []
         );
       } catch (err) {
@@ -138,10 +160,14 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
           return item?.id ?? index.toString();
         }}
         ListHeaderComponent={
-          <View>
+          <View style={{ marginBottom: 10 }}>
             <HomeChurchLocationSelect
               navigation={navigation}
-              loc={location?.locationData}
+              loc={
+                location?.locationData?.locationName.includes('Oakville')
+                  ? { ...location?.locationData, locationName: 'Oakville' }
+                  : location?.locationData
+              }
             />
             <Text
               style={style.resultsCount}
@@ -155,6 +181,7 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
               label="Map"
               style={{
                 marginLeft: 12,
+                paddingLeft: 8,
                 height: 50,
                 width: 100,
                 backgroundColor: '#fff',

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -1,0 +1,224 @@
+import React, { useContext, useEffect, useLayoutEffect, useState } from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  FlatList,
+  ActivityIndicator,
+} from 'react-native';
+import { Thumbnail } from 'native-base';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { MainStackParamList } from 'src/navigation/AppNavigator';
+import moment from 'moment';
+import API from '@aws-amplify/api';
+import { listF1ListGroup2s } from '../../services/queries';
+import { Theme, Style, HeaderStyle } from '../../Theme.style';
+import LocationContext from '../../contexts/LocationContext';
+
+const style = StyleSheet.create({
+  header: Style.header,
+  headerTitle: HeaderStyle.title,
+  resultsCount: {
+    fontFamily: Theme.fonts.fontFamilyBold,
+    fontSize: 16,
+    lineHeight: 18,
+    color: Theme.colors.grey5,
+    marginHorizontal: 16,
+    marginVertical: 8,
+  },
+  /* =========== HomeChurchCard Item=========== */
+  homeChurchCard: {
+    backgroundColor: Theme.colors.gray1,
+    padding: 16,
+  },
+  hmName: {
+    fontFamily: Theme.fonts.fontFamilyBold,
+    fontSize: 16,
+    lineHeight: 24,
+    color: 'white',
+  },
+  hmAddress: {
+    fontSize: 16,
+    lineHeight: 24,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    fontWeight: '400',
+    color: Theme.colors.grey5,
+  },
+  hmDate: {
+    marginVertical: 8,
+    color: 'white',
+    fontFamily: Theme.fonts.fontFamilyBold,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  hmDescription: {
+    color: Theme.colors.grey5,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  badgesContainer: {
+    marginTop: 24,
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  locationBadge: {
+    backgroundColor: Theme.colors.grey3,
+    borderRadius: 50,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  locationBadgeText: {
+    color: 'white',
+    fontSize: 12,
+    lineHeight: 18,
+    fontFamily: Theme.fonts.fontFamilyRegular,
+  },
+});
+
+interface Params {
+  navigation: StackNavigationProp<MainStackParamList>;
+}
+
+export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
+  const location = useContext(LocationContext);
+  const [isLoading, setIsLoading] = useState(true);
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: true,
+      title: 'Home Church Finder',
+      headerTitleStyle: style.headerTitle,
+      headerStyle: { backgroundColor: Theme.colors.background },
+      headerLeft: function render() {
+        return (
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              paddingRight: 12,
+              paddingBottom: 12,
+              paddingTop: 12,
+            }}
+          >
+            <Thumbnail
+              square
+              source={Theme.icons.white.back}
+              style={{ width: 24, height: 24 }}
+            />
+          </TouchableOpacity>
+        );
+      },
+      headerLeftContainerStyle: { left: 16 },
+      headerRight: function render() {
+        return <View style={{ flex: 1 }} />;
+      },
+    });
+  }, [navigation]);
+
+  const [homeChurches, setHomeChurches] = useState([]);
+  useEffect(() => {
+    const loadHomeChurches = async () => {
+      try {
+        const json = (await API.graphql({
+          query: listF1ListGroup2s,
+          variables: {
+            limit: 300,
+          },
+        })) as any;
+        setHomeChurches(
+          json.data.listF1ListGroup2s.items.filter(
+            (a) =>
+              a.location.address.city ===
+                location?.locationData?.locationName ?? 'Oakville'
+          )
+        );
+      } catch (err) {
+        console.log(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadHomeChurches();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const getDayOfWeek = (item) => {
+    if (item?.recurrences?.recurrence?.recurrenceWeekly)
+      if (item.recurrences.recurrence.recurrenceWeekly.occurOnSunday)
+        return 'Sunday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnMonday)
+        return 'Monday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnTuesday)
+        return 'Tuesday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnWednesday)
+        return 'Wednesday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnThursday)
+        return 'Thursday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnFriday)
+        return 'Friday';
+      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnSaturday)
+        return 'Saturday';
+      else return moment(item.startDate).format('dddd');
+    else return moment(item?.startDate).format('dddd');
+  };
+  const HomeChurchItem = ({ item }: any): JSX.Element => {
+    return (
+      <View style={style.homeChurchCard}>
+        <Text style={style.hmName}>{item.name}</Text>
+        <Text style={style.hmAddress}>{item.location.address.address1}</Text>
+        <Text style={style.hmDate}>
+          {getDayOfWeek(item)}s{'\n'}
+          {moment(item.schedule?.startTime).format('h:mm a')}
+        </Text>
+
+        <Text style={style.hmDescription}>{item.description}</Text>
+        <View style={style.badgesContainer}>
+          <View style={style.locationBadge}>
+            <Text style={style.locationBadgeText}>
+              {item.location.address.city}
+            </Text>
+          </View>
+        </View>
+      </View>
+    );
+  };
+  return (
+    <View>
+      <FlatList
+        data={homeChurches}
+        renderItem={({ item }) => <HomeChurchItem item={item} />}
+        keyExtractor={(item) => {
+          return item.id;
+        }}
+        ListHeaderComponent={
+          <View>
+            <Text
+              style={style.resultsCount}
+            >{`${homeChurches.length} Results`}</Text>
+          </View>
+        }
+        ListFooterComponent={
+          isLoading ? (
+            <View
+              style={{
+                backgroundColor: Theme.colors.gray1,
+                flex: 1,
+                justifyContent: 'center',
+                paddingVertical: 32,
+                alignItems: 'center',
+              }}
+            >
+              <ActivityIndicator
+                size="large"
+                color="white"
+                animating
+                style={{ height: 50, width: 50 }}
+              />
+            </View>
+          ) : null
+        }
+      />
+    </View>
+  );
+}

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -171,12 +171,11 @@ export default function HomeChurchScreen({
       {isLoading ? (
         <View
           style={{
-            // TODO: fix this centering
             flex: 1,
             justifyContent: 'center',
             position: 'absolute',
             zIndex: 200,
-            top: '100%',
+            top: '50%',
             left: '45%',
             paddingVertical: 32,
             alignItems: 'center',
@@ -193,6 +192,7 @@ export default function HomeChurchScreen({
       <ScrollView>
         <View style={{ marginBottom: 10 }}>
           <HomeChurchControls
+            isLoading={isLoading}
             setDay={setDay}
             navigation={navigation}
             loc={location}
@@ -222,9 +222,7 @@ export default function HomeChurchScreen({
               style={{
                 alignSelf: 'flex-end',
                 paddingLeft: 12,
-                height: 50,
                 marginRight: 16,
-                width: 100,
                 backgroundColor: '#fff',
               }}
               onPress={() =>

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -5,21 +5,22 @@ import {
   Text,
   FlatList,
   ActivityIndicator,
-  TextInput,
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { StackNavigationProp } from '@react-navigation/stack';
-import {
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-} from 'react-native-gesture-handler';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
-import moment from 'moment';
 import API, { GraphQLResult } from '@aws-amplify/api';
 import { ListF1ListGroup2sQuery } from 'src/services/API';
 import { listF1ListGroup2s } from '../../services/queries';
 import { Theme, Style, HeaderStyle } from '../../Theme.style';
 import LocationContext from '../../contexts/LocationContext';
+import HomeChurchItem from './HomeChurchItem';
+import HomeChurchLocationSelect from './HomeChurchLocationSelect';
+
+interface Params {
+  navigation: StackNavigationProp<MainStackParamList>;
+}
 
 const style = StyleSheet.create({
   header: Style.header,
@@ -32,16 +33,12 @@ const style = StyleSheet.create({
     marginHorizontal: 16,
     marginVertical: 8,
   },
-  /* =========== HomeChurchCard Item=========== */
 });
 
-interface Params {
-  navigation: StackNavigationProp<MainStackParamList>;
-}
 type HomeChurchData = NonNullable<
   NonNullable<NonNullable<ListF1ListGroup2sQuery>['listF1ListGroup2s']>['items']
 >;
-type HomeChurch = HomeChurchData[0];
+export type HomeChurch = HomeChurchData[0];
 
 export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
   const location = useContext(LocationContext);
@@ -92,13 +89,12 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
             limit: 500,
           },
         })) as GraphQLResult<ListF1ListGroup2sQuery>;
-        setHomeChurches(
-          json?.data?.listF1ListGroup2s?.items?.filter(
+        setHomeChurches(json?.data?.listF1ListGroup2s?.items ?? []);
+        /*          json?.data?.listF1ListGroup2s?.items?.filter(
             (a) =>
               a?.location?.address?.city ===
                 location?.locationData?.locationName ?? 'Oakville'
-          ) ?? []
-        );
+          ) ?? [] */
       } catch (err) {
         console.log(err);
       } finally {
@@ -108,237 +104,31 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
     loadHomeChurches();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location]);
-  const getDayOfWeek = (item) => {
-    if (item?.recurrences?.recurrence?.recurrenceWeekly)
-      if (item.recurrences.recurrence.recurrenceWeekly.occurOnSunday)
-        return 'Sunday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnMonday)
-        return 'Monday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnTuesday)
-        return 'Tuesday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnWednesday)
-        return 'Wednesday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnThursday)
-        return 'Thursday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnFriday)
-        return 'Friday';
-      else if (item.recurrences.recurrence.recurrenceWeekly.occurOnSaturday)
-        return 'Saturday';
-      else return moment(item.startDate).format('dddd');
-    else return moment(item?.startDate).format('dddd');
-  };
-  const HomeChurchLocationSelect = ({ loc }): JSX.Element => {
-    /*
-      TODO: Add clear all
-      TODO: Vertical alignment for location
-    */
-    const [selectedLocation, setSelectedLocation] = useState(
-      loc.locationData.locationName
-    );
-    const [postalCode, setPostalCode] = useState('');
-    const style = StyleSheet.create({
-      locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
-      container: {
-        backgroundColor: '#111111',
-        margin: 16,
-      },
-      containerItem: {
-        flexDirection: 'row',
-        fontFamily: Theme.fonts.fontFamilyRegular,
-        paddingHorizontal: 20,
-        color: 'white',
-        height: 56,
-        fontSize: 16,
-        borderWidth: 1,
-        borderColor: '#1A1A1A',
-      },
-      locationSelect: {
-        alignSelf: 'center',
-        flex: 1,
-        fontFamily: Theme.fonts.fontFamilyRegular,
-        color: '#fff',
-        fontSize: 16,
-      },
-    });
-    return (
-      <View style={style.container}>
-        <TouchableWithoutFeedback
-          onPress={() =>
-            navigation.push('LocationSelectionScreen', { persist: true })
-          }
-          style={style.containerItem}
-        >
-          <View style={{ flexDirection: 'row', flex: 1 }}>
-            <Thumbnail
-              style={style.locationIcon}
-              source={Theme.icons.white.location}
-              square
-            />
-            <Text style={style.locationSelect}>{selectedLocation}</Text>
-          </View>
-        </TouchableWithoutFeedback>
 
-        <TextInput
-          accessibilityLabel="Add Postal Code"
-          keyboardAppearance="dark"
-          placeholder="Add postal code"
-          placeholderTextColor="#646469"
-          textContentType="none"
-          keyboardType="default"
-          multiline
-          value={postalCode}
-          onChange={(text) => {
-            if (!text.nativeEvent.text.includes(' '))
-              setPostalCode(text.nativeEvent.text);
-          }}
-          textAlignVertical="center"
-          maxLength={6}
-          autoCapitalize="characters"
-          style={style.containerItem}
-        />
-      </View>
-    );
-  };
-  const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
-    const style = StyleSheet.create({
-      homeChurchCard: {
-        borderColor: '#1A1A1A',
-        borderWidth: 1,
-        backgroundColor: Theme.colors.gray1,
-        padding: 16,
-      },
-      hmName: {
-        fontFamily: Theme.fonts.fontFamilyBold,
-        fontSize: 16,
-        lineHeight: 24,
-        color: 'white',
-      },
-      hmAddress: {
-        fontSize: 16,
-        lineHeight: 24,
-        fontFamily: Theme.fonts.fontFamilyRegular,
-        fontWeight: '400',
-        color: Theme.colors.grey5,
-      },
-      hmDate: {
-        marginVertical: 8,
-        color: 'white',
-        fontFamily: Theme.fonts.fontFamilyBold,
-        fontSize: 12,
-        lineHeight: 18,
-      },
-      hmDescription: {
-        color: Theme.colors.grey5,
-        fontFamily: Theme.fonts.fontFamilyRegular,
-        fontSize: 12,
-        lineHeight: 18,
-      },
-      badgesContainer: {
-        marginTop: 24,
-        flexDirection: 'row',
-        justifyContent: 'flex-start',
-      },
-      locationBadge: {
-        backgroundColor: Theme.colors.grey3,
-        borderRadius: 50,
-        paddingHorizontal: 12,
-        marginHorizontal: 2,
-        justifyContent: 'center',
-        alignItems: 'center',
-        paddingVertical: 4,
-      },
-      locationBadgeText: {
-        color: 'white',
-        fontSize: 12,
-        lineHeight: 18,
-
-        fontFamily: Theme.fonts.fontFamilyRegular,
-      },
-    });
-    return (
-      <View style={style.homeChurchCard}>
-        <View style={{ flexDirection: 'row' }}>
-          <View style={{ flex: 1 }}>
-            <Text style={style.hmName}>{item.name}</Text>
-            <Text style={style.hmAddress}>
-              {item.location.address.address1}
-            </Text>
-            <Text style={style.hmDate}>
-              {getDayOfWeek(item)}s{'\n'}
-              {moment(item.schedule?.startTime).format('h:mm a')}
-            </Text>
-          </View>
-          <View>
-            <TouchableOpacity
-              style={{
-                width: 40,
-                height: 40,
-                margin: 4,
-                marginRight: 16,
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}
-            >
-              <Thumbnail
-                square
-                source={Theme.icons.white.calendarAdd}
-                style={{
-                  width: 24,
-                  height: 24,
-                }}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={{
-                width: 40,
-                height: 40,
-                margin: 4,
-                marginRight: 16,
-                justifyContent: 'center',
-                alignItems: 'center',
-              }}
-            >
-              <Thumbnail
-                square
-                source={Theme.icons.white.contact}
-                style={{
-                  width: 24,
-                  height: 24,
-                }}
-              />
-            </TouchableOpacity>
-          </View>
-        </View>
-
-        <Text style={style.hmDescription}>{item.description}</Text>
-        <View style={style.badgesContainer}>
-          <View style={style.locationBadge}>
-            <Text style={style.locationBadgeText}>
-              {item.location.address.city}
-            </Text>
-          </View>
-          {item.name.includes('Family Friendly') && (
-            <View
-              style={[
-                style.locationBadge,
-                {
-                  paddingHorizontal: 12,
-                  backgroundColor: 'rgb(160, 226, 186)',
-                },
-              ]}
-            >
-              <Thumbnail // is this getting cropped?
-                source={Theme.icons.black.familyFriendly}
-                style={{ width: 16, height: 16 }}
-              />
-            </View>
-          )}
-        </View>
-      </View>
-    );
-  };
   return (
     <View>
+      {isLoading ? (
+        <View
+          style={{
+            // TODO: fix this
+            flex: 1,
+            justifyContent: 'center',
+            position: 'absolute',
+            zIndex: 200,
+            top: '100%',
+            left: '45%',
+            paddingVertical: 32,
+            alignItems: 'center',
+          }}
+        >
+          <ActivityIndicator
+            size="large"
+            color="white"
+            animating
+            style={{ height: 50, width: 50 }}
+          />
+        </View>
+      ) : null}
       <FlatList
         data={homeChurches}
         renderItem={({ item }) => <HomeChurchItem item={item} />}
@@ -347,31 +137,22 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
         }}
         ListHeaderComponent={
           <View>
-            <HomeChurchLocationSelect loc={location} />
+            <HomeChurchLocationSelect navigation={navigation} loc={location} />
             <Text
               style={style.resultsCount}
             >{`${homeChurches.length} Results`}</Text>
           </View>
         }
         ListFooterComponent={
-          isLoading ? (
-            <View
-              style={{
-                backgroundColor: Theme.colors.gray1,
-                flex: 1,
-                justifyContent: 'center',
-                paddingVertical: 32,
-                alignItems: 'center',
-              }}
-            >
-              <ActivityIndicator
-                size="large"
-                color="white"
-                animating
-                style={{ height: 50, width: 50 }}
-              />
-            </View>
-          ) : null
+          <TouchableOpacity
+            onPress={() => {
+              navigation.navigate('HomeChurchMapScreen', {
+                items: homeChurches,
+              });
+            }}
+          >
+            <Text style={{ color: 'white' }}>GO TO MAP</Text>
+          </TouchableOpacity>
         }
       />
     </View>

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -224,11 +224,17 @@ export default function HomeChurchScreen({
               }}
               onPress={() =>
                 navigation.navigate('HomeChurchMapScreen', {
-                  items: homeChurches.filter(
-                    (church) =>
-                      church?.location?.address?.latitude !== '' &&
-                      church?.location?.address?.longitude !== ''
-                  ),
+                  items: homeChurches
+                    .sort((a, b) =>
+                      a?.groupType?.id && b?.groupType?.id
+                        ? a?.groupType?.id?.localeCompare(b?.groupType?.id)
+                        : 0
+                    )
+                    .filter(
+                      (church) =>
+                        church?.location?.address?.latitude !== '' &&
+                        church?.location?.address?.longitude !== ''
+                    ),
                 })
               }
             />

--- a/src/screens/homechurch/HomeChurchScreen.tsx
+++ b/src/screens/homechurch/HomeChurchScreen.tsx
@@ -5,13 +5,18 @@ import {
   Text,
   FlatList,
   ActivityIndicator,
+  TextInput,
 } from 'react-native';
 import { Thumbnail } from 'native-base';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import {
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+} from 'react-native-gesture-handler';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
 import moment from 'moment';
-import API from '@aws-amplify/api';
+import API, { GraphQLResult } from '@aws-amplify/api';
+import { ListF1ListGroup2sQuery } from 'src/services/API';
 import { listF1ListGroup2s } from '../../services/queries';
 import { Theme, Style, HeaderStyle } from '../../Theme.style';
 import LocationContext from '../../contexts/LocationContext';
@@ -28,58 +33,15 @@ const style = StyleSheet.create({
     marginVertical: 8,
   },
   /* =========== HomeChurchCard Item=========== */
-  homeChurchCard: {
-    backgroundColor: Theme.colors.gray1,
-    padding: 16,
-  },
-  hmName: {
-    fontFamily: Theme.fonts.fontFamilyBold,
-    fontSize: 16,
-    lineHeight: 24,
-    color: 'white',
-  },
-  hmAddress: {
-    fontSize: 16,
-    lineHeight: 24,
-    fontFamily: Theme.fonts.fontFamilyRegular,
-    fontWeight: '400',
-    color: Theme.colors.grey5,
-  },
-  hmDate: {
-    marginVertical: 8,
-    color: 'white',
-    fontFamily: Theme.fonts.fontFamilyBold,
-    fontSize: 12,
-    lineHeight: 18,
-  },
-  hmDescription: {
-    color: Theme.colors.grey5,
-    fontFamily: Theme.fonts.fontFamilyRegular,
-    fontSize: 12,
-    lineHeight: 18,
-  },
-  badgesContainer: {
-    marginTop: 24,
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-  },
-  locationBadge: {
-    backgroundColor: Theme.colors.grey3,
-    borderRadius: 50,
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-  },
-  locationBadgeText: {
-    color: 'white',
-    fontSize: 12,
-    lineHeight: 18,
-    fontFamily: Theme.fonts.fontFamilyRegular,
-  },
 });
 
 interface Params {
   navigation: StackNavigationProp<MainStackParamList>;
 }
+type HomeChurchData = NonNullable<
+  NonNullable<NonNullable<ListF1ListGroup2sQuery>['listF1ListGroup2s']>['items']
+>;
+type HomeChurch = HomeChurchData[0];
 
 export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
   const location = useContext(LocationContext);
@@ -117,22 +79,25 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
     });
   }, [navigation]);
 
-  const [homeChurches, setHomeChurches] = useState([]);
+  const [homeChurches, setHomeChurches] = useState<HomeChurchData>([]);
   useEffect(() => {
+    /*
+      TODO: Not all locations are showing. City names not matching?
+    */
     const loadHomeChurches = async () => {
       try {
         const json = (await API.graphql({
           query: listF1ListGroup2s,
           variables: {
-            limit: 300,
+            limit: 500,
           },
-        })) as any;
+        })) as GraphQLResult<ListF1ListGroup2sQuery>;
         setHomeChurches(
-          json.data.listF1ListGroup2s.items.filter(
+          json?.data?.listF1ListGroup2s?.items?.filter(
             (a) =>
-              a.location.address.city ===
+              a?.location?.address?.city ===
                 location?.locationData?.locationName ?? 'Oakville'
-          )
+          ) ?? []
         );
       } catch (err) {
         console.log(err);
@@ -142,7 +107,7 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
     };
     loadHomeChurches();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [location]);
   const getDayOfWeek = (item) => {
     if (item?.recurrences?.recurrence?.recurrenceWeekly)
       if (item.recurrences.recurrence.recurrenceWeekly.occurOnSunday)
@@ -162,15 +127,188 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
       else return moment(item.startDate).format('dddd');
     else return moment(item?.startDate).format('dddd');
   };
-  const HomeChurchItem = ({ item }: any): JSX.Element => {
+  const HomeChurchLocationSelect = ({ loc }): JSX.Element => {
+    /*
+      TODO: Add clear all
+      TODO: Vertical alignment for location
+    */
+    const [selectedLocation, setSelectedLocation] = useState(
+      loc.locationData.locationName
+    );
+    const [postalCode, setPostalCode] = useState('');
+    const style = StyleSheet.create({
+      locationIcon: { ...Style.icon, marginRight: 20, alignSelf: 'center' },
+      container: {
+        backgroundColor: '#111111',
+        margin: 16,
+      },
+      containerItem: {
+        flexDirection: 'row',
+        fontFamily: Theme.fonts.fontFamilyRegular,
+        paddingHorizontal: 20,
+        color: 'white',
+        height: 56,
+        fontSize: 16,
+        borderWidth: 1,
+        borderColor: '#1A1A1A',
+      },
+      locationSelect: {
+        alignSelf: 'center',
+        flex: 1,
+        fontFamily: Theme.fonts.fontFamilyRegular,
+        color: '#fff',
+        fontSize: 16,
+      },
+    });
+    return (
+      <View style={style.container}>
+        <TouchableWithoutFeedback
+          onPress={() =>
+            navigation.push('LocationSelectionScreen', { persist: true })
+          }
+          style={style.containerItem}
+        >
+          <View style={{ flexDirection: 'row', flex: 1 }}>
+            <Thumbnail
+              style={style.locationIcon}
+              source={Theme.icons.white.location}
+              square
+            />
+            <Text style={style.locationSelect}>{selectedLocation}</Text>
+          </View>
+        </TouchableWithoutFeedback>
+
+        <TextInput
+          accessibilityLabel="Add Postal Code"
+          keyboardAppearance="dark"
+          placeholder="Add postal code"
+          placeholderTextColor="#646469"
+          textContentType="none"
+          keyboardType="default"
+          multiline
+          value={postalCode}
+          onChange={(text) => {
+            if (!text.nativeEvent.text.includes(' '))
+              setPostalCode(text.nativeEvent.text);
+          }}
+          textAlignVertical="center"
+          maxLength={6}
+          autoCapitalize="characters"
+          style={style.containerItem}
+        />
+      </View>
+    );
+  };
+  const HomeChurchItem = ({ item }: HomeChurch): JSX.Element => {
+    const style = StyleSheet.create({
+      homeChurchCard: {
+        borderColor: '#1A1A1A',
+        borderWidth: 1,
+        backgroundColor: Theme.colors.gray1,
+        padding: 16,
+      },
+      hmName: {
+        fontFamily: Theme.fonts.fontFamilyBold,
+        fontSize: 16,
+        lineHeight: 24,
+        color: 'white',
+      },
+      hmAddress: {
+        fontSize: 16,
+        lineHeight: 24,
+        fontFamily: Theme.fonts.fontFamilyRegular,
+        fontWeight: '400',
+        color: Theme.colors.grey5,
+      },
+      hmDate: {
+        marginVertical: 8,
+        color: 'white',
+        fontFamily: Theme.fonts.fontFamilyBold,
+        fontSize: 12,
+        lineHeight: 18,
+      },
+      hmDescription: {
+        color: Theme.colors.grey5,
+        fontFamily: Theme.fonts.fontFamilyRegular,
+        fontSize: 12,
+        lineHeight: 18,
+      },
+      badgesContainer: {
+        marginTop: 24,
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+      },
+      locationBadge: {
+        backgroundColor: Theme.colors.grey3,
+        borderRadius: 50,
+        paddingHorizontal: 12,
+        marginHorizontal: 2,
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingVertical: 4,
+      },
+      locationBadgeText: {
+        color: 'white',
+        fontSize: 12,
+        lineHeight: 18,
+
+        fontFamily: Theme.fonts.fontFamilyRegular,
+      },
+    });
     return (
       <View style={style.homeChurchCard}>
-        <Text style={style.hmName}>{item.name}</Text>
-        <Text style={style.hmAddress}>{item.location.address.address1}</Text>
-        <Text style={style.hmDate}>
-          {getDayOfWeek(item)}s{'\n'}
-          {moment(item.schedule?.startTime).format('h:mm a')}
-        </Text>
+        <View style={{ flexDirection: 'row' }}>
+          <View style={{ flex: 1 }}>
+            <Text style={style.hmName}>{item.name}</Text>
+            <Text style={style.hmAddress}>
+              {item.location.address.address1}
+            </Text>
+            <Text style={style.hmDate}>
+              {getDayOfWeek(item)}s{'\n'}
+              {moment(item.schedule?.startTime).format('h:mm a')}
+            </Text>
+          </View>
+          <View>
+            <TouchableOpacity
+              style={{
+                width: 40,
+                height: 40,
+                margin: 4,
+                marginRight: 16,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Thumbnail
+                square
+                source={Theme.icons.white.calendarAdd}
+                style={{
+                  width: 24,
+                  height: 24,
+                }}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={{
+                width: 40,
+                height: 40,
+                margin: 4,
+                marginRight: 16,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Thumbnail
+                square
+                source={Theme.icons.white.contact}
+                style={{
+                  width: 24,
+                  height: 24,
+                }}
+              />
+            </TouchableOpacity>
+          </View>
+        </View>
 
         <Text style={style.hmDescription}>{item.description}</Text>
         <View style={style.badgesContainer}>
@@ -179,6 +317,22 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
               {item.location.address.city}
             </Text>
           </View>
+          {item.name.includes('Family Friendly') && (
+            <View
+              style={[
+                style.locationBadge,
+                {
+                  paddingHorizontal: 12,
+                  backgroundColor: 'rgb(160, 226, 186)',
+                },
+              ]}
+            >
+              <Thumbnail // is this getting cropped?
+                source={Theme.icons.black.familyFriendly}
+                style={{ width: 16, height: 16 }}
+              />
+            </View>
+          )}
         </View>
       </View>
     );
@@ -188,11 +342,12 @@ export default function HomeChurchScreen({ navigation }: Params): JSX.Element {
       <FlatList
         data={homeChurches}
         renderItem={({ item }) => <HomeChurchItem item={item} />}
-        keyExtractor={(item) => {
-          return item.id;
+        keyExtractor={(item, index) => {
+          return item?.id ?? index.toString();
         }}
         ListHeaderComponent={
           <View>
+            <HomeChurchLocationSelect loc={location} />
             <Text
               style={style.resultsCount}
             >{`${homeChurches.length} Results`}</Text>

--- a/src/screens/more/MoreScreen.tsx
+++ b/src/screens/more/MoreScreen.tsx
@@ -146,8 +146,7 @@ export default function MoreScreen(): JSX.Element {
         text: 'Home Church',
         subtext: 'Find a home church near you',
         icon: Theme.icons.white.homeChurch,
-        action: () =>
-          Linking.openURL('https://www.themeetinghouse.com/find-homechurch'),
+        action: () => navigation.navigate('HomeChurchScreen', {}),
       },
       {
         id: 'volunteer',
@@ -207,7 +206,7 @@ export default function MoreScreen(): JSX.Element {
         text: 'Home Church',
         subtext: 'Find a home church near you',
         icon: Theme.icons.white.homeChurch,
-        action: () => navigation.navigate('HomeChurchScreen'),
+        action: () => navigation.navigate('HomeChurchScreen', {}),
       },
       {
         id: 'volunteer',

--- a/src/screens/more/MoreScreen.tsx
+++ b/src/screens/more/MoreScreen.tsx
@@ -207,8 +207,7 @@ export default function MoreScreen(): JSX.Element {
         text: 'Home Church',
         subtext: 'Find a home church near you',
         icon: Theme.icons.white.homeChurch,
-        action: () =>
-          Linking.openURL('https://www.themeetinghouse.com/find-homechurch'),
+        action: () => navigation.navigate('HomeChurchScreen'),
       },
       {
         id: 'volunteer',

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -546,6 +546,10 @@ export const listF1ListGroup2s = /* GraphQL */ `
         name
         description
         startDate
+        timeZone {
+          name
+          id
+        }
         groupType {
           id
           name

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -546,6 +546,10 @@ export const listF1ListGroup2s = /* GraphQL */ `
         name
         description
         startDate
+        groupType {
+          id
+          name
+        }
         location {
           id
           name

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -534,6 +534,74 @@ export const getVideoByVideoType = /* GraphQL */ `
   }
 `;
 
+export const listF1ListGroup2s = /* GraphQL */ `
+  query ListF1ListGroup2s(
+    $filter: ModelF1ListGroup2FilterInput
+    $limit: Int
+    $nextToken: String
+  ) {
+    listF1ListGroup2s(filter: $filter, limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        name
+        description
+        startDate
+        location {
+          id
+          name
+          description
+          isOnline
+          url
+          address {
+            address1
+            address2
+            address3
+            city
+            postalCode
+            latitude
+            longitude
+          }
+          createdDate
+          lastUpdatedDate
+        }
+        schedule {
+          id
+          name
+          description
+          startTime
+          endTime
+          numberRecurrences
+          startDate
+          endDate
+          recurrenceType {
+            name
+          }
+          recurrences {
+            recurrence {
+              recurrenceWeekly {
+                recurrenceFrequency
+                occurOnSunday
+                occurOnMonday
+                occurOnTuesday
+                occurOnWednesday
+                occurOnThursday
+                occurOnFriday
+                occurOnSaturday
+              }
+              recurrenceMonthly {
+                recurrenceFrequency
+                recurrenceOffset
+                monthDay
+                monthWeekDay
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const listSpeakersNoVideos = `
   query ListSpeakers(
     $filter: ModelSpeakerFilterInput


### PR DESCRIPTION
* [x] Display Home Church module on home page with graphic, description and action taking you to Home Church finder
* [x] Filters home churches by user location, shows all if no location is set
* [x] Ability to find home churches by location
* [x] Ability to find home churches by week day of occurrence
* [x] Home church results should display: name, address, date, time, leader, site tag, HC category tag
* [x] Add to calendar button adds the next occurrence of home church to calendar
* [x] Email button opens default e-mail app with pre-populated data to allow user to email home church leader
* [x] Confirmation modals popup for calendar and email buttons
* [x] Point "Find a home church" in "More" to Home Church screens rather than the website

[Needs API key for deployment](https://docs.expo.io/versions/latest/sdk/map-view/#configuration) @GeorgeBellTMH

closes #171



┆Issue is synchronized with this [Wrike Task](https://www.wrike.com/open.htm?id=692430242)
