### PR TITLE
Fix for missing teaching thumbnail

### DIFF
--- a/src/components/home/RecentTeaching.tsx
+++ b/src/components/home/RecentTeaching.tsx
@@ -86,7 +86,10 @@ export default function RecentTeaching({ note, teaching }: Props): JSX.Element {
       ''
     )}.jpg`;
     const teachingImage =
-      teaching?.Youtube?.snippet?.thumbnails?.standard ?? null;
+      teaching?.Youtube?.snippet?.thumbnails?.standard ??
+      teaching?.Youtube?.snippet?.thumbnails?.high ??
+      teaching?.Youtube?.snippet?.thumbnails?.medium ??
+      null;
 
     const openNotes = () => {
       navigation.push('NotesScreen', {


### PR DESCRIPTION


┆Issue is synchronized with this [Wrike Item](https://www.wrike.com/open.htm?id=738713840)
