### PR TITLE
Added useDebounce hook

### DIFF
--- a/src/components/HighlightCarousel.tsx
+++ b/src/components/HighlightCarousel.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
 import { MainStackParamList } from 'src/navigation/AppNavigator';
+import useDebounce from '../../src/hooks/useDebounce';
 import SermonsService from '../services/SermonsService';
 import loadSomeAsync from '../utils/loading';
 import GenericCarousel from './GenericCarousel';
@@ -13,7 +14,7 @@ export default function HighlightCarousel(): JSX.Element {
     loading: true,
     nextToken: undefined,
   });
-
+  const { debounce } = useDebounce();
   const loadHighlights = async () => {
     loadSomeAsync(
       SermonsService.loadHighlightsList,
@@ -37,7 +38,9 @@ export default function HighlightCarousel(): JSX.Element {
   }, []);
   return (
     <GenericCarousel
-      handleNavigation={(item, index) => handleNavigation(item, index ?? -1)}
+      handleNavigation={(item, index) =>
+        debounce(() => handleNavigation(item, index ?? -1))
+      }
       loadMore={loadHighlights}
       data={{
         items: highlights.items,

--- a/src/components/SuggestedCarousel.tsx
+++ b/src/components/SuggestedCarousel.tsx
@@ -1,12 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
+import useDebounce from '../../src/hooks/useDebounce';
 import { MainStackParamList } from '../navigation/AppNavigator';
 import SeriesService from '../services/SeriesService';
 import GenericCarousel from './GenericCarousel';
 
 export default function HighlightCarousel(): JSX.Element {
   const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
+  const { debounce } = useDebounce();
   const [suggestedVideos, setSuggestedVideos] = useState({
     items: [],
     loading: true,
@@ -35,7 +37,7 @@ export default function HighlightCarousel(): JSX.Element {
   }, []);
   return (
     <GenericCarousel
-      handleNavigation={(item) => handleNavigation(item)}
+      handleNavigation={(item) => debounce(() => handleNavigation(item))}
       data={{
         items: suggestedVideos.items,
         loading: suggestedVideos.loading,

--- a/src/components/home/AnnouncementBar.tsx
+++ b/src/components/home/AnnouncementBar.tsx
@@ -5,6 +5,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { MainStackParamList } from '../../navigation/AppNavigator';
 import { Theme } from '../../Theme.style';
+import useDebounce from '../../../src/hooks/useDebounce';
 
 interface Props {
   message: string;
@@ -12,6 +13,7 @@ interface Props {
 
 export default function AnnouncementBar({ message }: Props): JSX.Element {
   const navigation = useNavigation<StackNavigationProp<MainStackParamList>>();
+  const { debounce } = useDebounce();
   const style = StyleSheet.create({
     container: {
       backgroundColor: Theme.colors.yellow,
@@ -34,7 +36,7 @@ export default function AnnouncementBar({ message }: Props): JSX.Element {
   return (
     <TouchableOpacity
       style={style.container}
-      onPress={() => navigation.push('LiveStreamScreen')}
+      onPress={() => debounce(() => navigation.push('LiveStreamScreen'))}
     >
       <Text style={style.message}>{message}</Text>
     </TouchableOpacity>

--- a/src/components/teaching/SeriesItem.tsx
+++ b/src/components/teaching/SeriesItem.tsx
@@ -4,6 +4,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { Theme } from '../../Theme.style';
 import FallbackImage from '../FallbackImage';
 import { TeachingStackParamList } from '../../navigation/MainTabNavigator';
+import useDebounce from '../../../src/hooks/useDebounce';
 
 const { width } = Dimensions.get('screen');
 
@@ -44,15 +45,18 @@ export default function SeriesItem({
   year,
   customPlaylist,
 }: Params): JSX.Element {
+  const { debounce } = useDebounce();
   return (
     <TouchableOpacity
-      onPress={() => {
-        navigation.push('SeriesLandingScreen', {
-          item: seriesData,
-          seriesId: seriesData.id,
-          customPlaylist,
-        });
-      }}
+      onPress={() =>
+        debounce(() =>
+          navigation.push('SeriesLandingScreen', {
+            item: seriesData,
+            seriesId: seriesData.id,
+            customPlaylist,
+          })
+        )
+      }
       style={style.seriesItem}
     >
       <FallbackImage

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+
+type Callback = () => unknown | Promise<unknown>;
+export default function useDebounce() {
+  const busy = useRef(false);
+  const debounce = async (callback: Callback, delay = 1000) => {
+    setTimeout(() => {
+      busy.current = false;
+    }, delay);
+
+    if (!busy.current) {
+      busy.current = true;
+      if (callback) callback();
+    }
+  };
+
+  return { debounce };
+}

--- a/src/screens/teaching/SeriesLandingScreen.tsx
+++ b/src/screens/teaching/SeriesLandingScreen.tsx
@@ -21,6 +21,7 @@ import { RouteProp, useTheme } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import API, { graphqlOperation, GraphQLResult } from '@aws-amplify/api';
+import useDebounce from '../../../src/hooks/useDebounce';
 import TeachingListItem from '../../components/teaching/TeachingListItem';
 import SeriesService, { SeriesHighlights } from '../../services/SeriesService';
 import ActivityIndicator from '../../components/ActivityIndicator';
@@ -170,6 +171,7 @@ export default function SeriesLandingScreen({
   navigation,
   route,
 }: Params): JSX.Element {
+  const { debounce } = useDebounce();
   const seriesParam = route.params?.item;
   const { seriesId, customPlaylist } = route.params;
   const safeArea = useSafeAreaInsets();
@@ -402,16 +404,18 @@ export default function SeriesLandingScreen({
                           key={seriesSermon?.id}
                           teaching={seriesSermon as any}
                           handlePress={() =>
-                            navigation.push(
-                              'SermonLandingScreen',
-                              route?.params?.customPlaylist
-                                ? {
-                                    item: seriesSermon,
-                                    customPlaylist:
-                                      route?.params?.customPlaylist,
-                                    seriesId,
-                                  }
-                                : { item: seriesSermon }
+                            debounce(() =>
+                              navigation.push(
+                                'SermonLandingScreen',
+                                route?.params?.customPlaylist
+                                  ? {
+                                      item: seriesSermon,
+                                      customPlaylist:
+                                        route?.params?.customPlaylist,
+                                      seriesId,
+                                    }
+                                  : { item: seriesSermon }
+                              )
                             )
                           }
                         />

--- a/src/screens/teaching/SermonLandingScreen.tsx
+++ b/src/screens/teaching/SermonLandingScreen.tsx
@@ -35,6 +35,7 @@ import ShareModal from '../../components/modals/Share';
 import { GetCustomPlaylistQuery, GetSeriesQuery } from '../../services/API';
 import NotesService from '../../services/NotesService';
 import { getSeries, getCustomPlaylist } from '../../graphql/queries';
+import useDebounce from '../../../src/hooks/useDebounce';
 
 const style = StyleSheet.create({
   content: {
@@ -136,6 +137,7 @@ export default function SermonLandingScreen({
   navigation,
   route,
 }: Params): JSX.Element {
+  const { debounce } = useDebounce();
   const sermon = route.params?.item;
   const mediaContext = useContext(MediaContext);
   const [sermonsInSeries, setSermonsInSeries] = useState<VideoData>();
@@ -518,11 +520,13 @@ export default function SermonLandingScreen({
                           key={video?.video?.id}
                           teaching={video.video}
                           handlePress={() =>
-                            navigation.push('SermonLandingScreen', {
-                              customPlaylist: true,
-                              seriesId: route.params?.seriesId,
-                              item: video.video,
-                            })
+                            debounce(() =>
+                              navigation.push('SermonLandingScreen', {
+                                customPlaylist: true,
+                                seriesId: route.params?.seriesId,
+                                item: video.video,
+                              })
+                            )
                           }
                         />
                       );
@@ -540,9 +544,11 @@ export default function SermonLandingScreen({
                         key={seriesSermon?.id}
                         teaching={seriesSermon}
                         handlePress={() =>
-                          navigation.push('SermonLandingScreen', {
-                            item: seriesSermon,
-                          })
+                          debounce(() =>
+                            navigation.push('SermonLandingScreen', {
+                              item: seriesSermon,
+                            })
+                          )
                         }
                       />
                     ) : null
@@ -766,7 +772,7 @@ export default function SermonLandingScreen({
               rightArrow
               icon={Theme.icons.white.notes}
               label="Notes"
-              onPress={navigateToNotes}
+              onPress={() => debounce(navigateToNotes)}
               data-testID="notes-button"
             />
           )}

--- a/src/screens/teaching/TeachingScreen.tsx
+++ b/src/screens/teaching/TeachingScreen.tsx
@@ -18,6 +18,7 @@ import SideSwipe from 'react-native-sideswipe';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { CompositeNavigationProp } from '@react-navigation/native';
 import API, { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api';
+import useDebounce from '../../../src/hooks/useDebounce';
 import { Theme, Style, HeaderStyle } from '../../Theme.style';
 import AllButton from '../../components/buttons/AllButton';
 import TeachingListItem from '../../components/teaching/TeachingListItem';
@@ -211,6 +212,7 @@ interface PopularSeriesData {
 export default function TeachingScreen({ navigation }: Params): JSX.Element {
   const { pageConfig } = useTeachingConfig();
   const user = useContext(UserContext);
+  const { debounce } = useDebounce();
   const [recentTeaching, setRecentTeaching] = useState({
     loading: true,
     items: [],
@@ -390,7 +392,9 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
     return (
       <TouchableWithoutFeedback
         key={item.id}
-        onPress={() => navigation.push('SeriesLandingScreen', { item })}
+        onPress={() =>
+          debounce(() => navigation.push('SeriesLandingScreen', { item }))
+        }
       >
         <View style={style.seriesThumbnailContainer}>
           <AnimatedFallbackImage
@@ -427,6 +431,7 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
     if (!a?.viewCount || !b?.viewCount) return -1;
     return parseInt(b.viewCount, 10) - parseInt(a.viewCount, 10);
   }
+
   return (
     <ScrollView
       style={style.content}
@@ -454,7 +459,7 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
           />
           <AllButton
             handlePress={() => {
-              navigation.push('AllSeriesScreen');
+              debounce(() => navigation.push('AllSeriesScreen'));
             }}
           >
             All series
@@ -474,14 +479,18 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
                   key={teaching.id}
                   teaching={teaching}
                   handlePress={() =>
-                    navigation.push('SermonLandingScreen', { item: teaching })
+                    debounce(() =>
+                      navigation.push('SermonLandingScreen', {
+                        item: teaching,
+                      })
+                    )
                   }
                 />
               ))}
           </View>
           <AllButton
             handlePress={() => {
-              navigation.push('AllSermonsScreen');
+              debounce(() => navigation.push('AllSermonsScreen'));
             }}
           >
             All sermons
@@ -503,7 +512,9 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
                   key={video?.id}
                   teaching={video}
                   handlePress={() =>
-                    navigation.push('SermonLandingScreen', { item: video })
+                    debounce(() =>
+                      navigation.push('SermonLandingScreen', { item: video })
+                    )
                   }
                 />
               ))}
@@ -551,7 +562,9 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
           </View>
           <AllButton
             handlePress={() =>
-              navigation.push('AllSeriesScreen', { popularSeries: true })
+              debounce(() =>
+                navigation.push('AllSeriesScreen', { popularSeries: true })
+              )
             }
           >
             More Popular Series
@@ -591,7 +604,9 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
           </View>
           <AllButton
             handlePress={() =>
-              navigation.push('AllSeriesScreen', { customPlaylists: true })
+              debounce(() =>
+                navigation.push('AllSeriesScreen', { customPlaylists: true })
+              )
             }
           >
             More Teaching Topics
@@ -649,7 +664,11 @@ export default function TeachingScreen({ navigation }: Params): JSX.Element {
                   speakers.loading ? <ActivityIndicator /> : null
                 }
               />
-              <AllButton handlePress={() => navigation.push('TeacherList')}>
+              <AllButton
+                handlePress={() =>
+                  debounce(() => navigation.push('TeacherList'))
+                }
+              >
                 All teachers
               </AllButton>
             </>


### PR DESCRIPTION
allows for keeping `navigate.push` behavior while preventing double navigation. Should work in most instances.
`const { debounce } = useDebounce();`
`debounce(function, delay)` takes a function and optional delay in milliseconds. defaults to 1 second

closes #127



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=895733903)
